### PR TITLE
配列要素の子要素が配列のオブジェクトの場合に問題なく出力されるように

### DIFF
--- a/src/main/java/nablarch/core/dataformat/XmlDataBuilder.java
+++ b/src/main/java/nablarch/core/dataformat/XmlDataBuilder.java
@@ -193,8 +193,9 @@ public class XmlDataBuilder extends StructuredDataEditorSupport implements Struc
         }
 
         final String withSeparator = prefix + '.';
+        final String withArray = prefix + '[';
         for (final String key : map.keySet()) {
-            if (key.equals(prefix) || key.startsWith(withSeparator)) {
+            if (key.equals(prefix) || key.startsWith(withSeparator) || key.startsWith(withArray)) {
                 return true;
             }
         }

--- a/src/test/java/nablarch/core/dataformat/XmlDataBuilderTest.java
+++ b/src/test/java/nablarch/core/dataformat/XmlDataBuilderTest.java
@@ -1549,6 +1549,108 @@ public class XmlDataBuilderTest {
     }
 
     @Test
+    public void 配列の子要素に配列オブジェクトが出力できること() throws Exception {
+        createFormatFile(
+                "UTF-8",
+                "[parent]",
+                "1 children [1..*] OB",
+                "[children]",
+                "1 grandchildren [1..*] OB",
+                "[grandchildren]",
+                "1 name X"
+        );
+
+        final HashMap<String, Object> input = new HashMap<String, Object>();
+        input.put("children[0].grandchildren[0].name", "孫1-1");
+        input.put("children[0].grandchildren[1].name", "孫1-2");
+        input.put("children[1].grandchildren[0].name", "孫2-1");
+        final ByteArrayOutputStream actual = new ByteArrayOutputStream();
+        sut.buildData(input, getLayoutDefinition(), actual);
+
+        System.out.println(actual.toString("utf-8"));
+
+        assertThat(actual.toString("utf-8"), isIdenticalTo(
+                "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n"
+                        + "<parent>\n"
+                        + "  <children>\n"
+                        + "    <grandchildren>\n"
+                        + "      <name>孫1-1</name>\n"
+                        + "    </grandchildren>\n"
+                        + "    <grandchildren>\n"
+                        + "      <name>孫1-2</name>\n"
+                        + "    </grandchildren>\n"
+                        + "  </children>\n"
+                        + "  <children>\n"
+                        + "    <grandchildren>\n"
+                        + "      <name>孫2-1</name>\n"
+                        + "    </grandchildren>\n"
+                        + "  </children>\n"
+                        + "</parent>"
+        ).ignoreWhitespace());
+    }
+
+    @Test
+    public void 配列の子要素の任意配列オブジェクトが省略できること() throws Exception {
+        createFormatFile(
+                "UTF-8",
+                "[parent]",
+                "1 children [1..*] OB",
+                "[children]",
+                "1 grandchildren [0..*] OB",
+                "[grandchildren]",
+                "1 name X"
+        );
+
+        final HashMap<String, Object> input = new HashMap<String, Object>();
+        input.put("children[0].grandchildren", null);
+        input.put("children[1].grandchildren[0].name", "孫2-1");
+        input.put("children[1].grandchildren[1].name", "孫2-2");
+        final ByteArrayOutputStream actual = new ByteArrayOutputStream();
+        sut.buildData(input, getLayoutDefinition(), actual);
+
+        System.out.println(actual.toString("utf-8"));
+
+        assertThat(actual.toString("utf-8"), isIdenticalTo(
+                "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n"
+                        + "<parent>\n"
+                        + "  <children>\n"
+                        + "  </children>\n"
+                        + "  <children>\n"
+                        + "    <grandchildren>\n"
+                        + "      <name>孫2-1</name>\n"
+                        + "    </grandchildren>\n"
+                        + "    <grandchildren>\n"
+                        + "      <name>孫2-2</name>\n"
+                        + "    </grandchildren>\n"
+                        + "  </children>\n"
+                        + "</parent>"
+        ).ignoreWhitespace());
+    }
+
+    @Test
+    public void 配列の子要素の必須配列オブジェクトを指定しなかった場合エラーとなること() throws Exception {
+        createFormatFile(
+                "UTF-8",
+                "[parent]",
+                "1 children [1..*] OB",
+                "[children]",
+                "1 grandchildren [1..*] OB",
+                "[grandchildren]",
+                "1 name X"
+        );
+
+        final HashMap<String, Object> input = new HashMap<String, Object>();
+        input.put("children[0].grandchildren[0].name", "孫1-1");
+        input.put("children[0].grandchildren[1].name", "孫1-2");
+        input.put("children[1].grandchildren", null);
+        final ByteArrayOutputStream actual = new ByteArrayOutputStream();
+
+        expectedException.expect(InvalidDataFormatException.class);
+        expectedException.expectMessage("Out of range array length BaseKey = children[1],FieldName=grandchildren");
+        sut.buildData(input, getLayoutDefinition(), actual);
+    }
+
+    @Test
     public void 出力対象にnullを指定した場合で子要素を持つ場合ルート要素だけが出力されること() throws Exception {
         createFormatFile(
                 "UTF-8",


### PR DESCRIPTION
配列要素の子要素が配列のオブジェクトの場合、さらに子を見るように変更しました。
さらに子を見る判定をする処理に配列の場合（'要素名['で始まる場合）を追加しました。
#17