### PR TITLE
datatype配下にテストを追加する

### DIFF
--- a/src/main/java/nablarch/core/dataformat/convertor/datatype/ByteStreamDataString.java
+++ b/src/main/java/nablarch/core/dataformat/convertor/datatype/ByteStreamDataString.java
@@ -35,6 +35,10 @@ public class ByteStreamDataString extends ByteStreamDataSupport<String> {
 
     /** {@inheritDoc} */
     public ByteStreamDataString initialize(Object... args) {
+        if (args == null) {
+            throw new SyntaxErrorException(Builder.concat(
+                    "initialize parameter was null. parameter must be specified. convertor=[", getClass().getSimpleName(), "]."));
+        }
         if (args.length == 0) {
             throw new SyntaxErrorException(Builder.concat(
                     "parameter was not specified. parameter must be specified. convertor=[", getClass().getSimpleName(), "]."));

--- a/src/main/java/nablarch/core/dataformat/convertor/datatype/Bytes.java
+++ b/src/main/java/nablarch/core/dataformat/convertor/datatype/Bytes.java
@@ -34,6 +34,12 @@ public class Bytes extends ByteStreamDataSupport<byte[]> {
                             "invalid parameter type was specified. parameter type must be 'Integer' but was: '%s'. parameter=%s. convertor=[Bytes].",
                             args[0].getClass().getName(), Arrays.toString(args)));
         }
+        if ((Integer)args[0] <= 0) {
+            throw new SyntaxErrorException(
+                    String.format(
+                            "invalid parameter was specified. 1st parameter must be positive number, but was [%d]. parameter=%s.",
+                            args[0], Arrays.toString(args)));
+        }
         setSize((Integer) args[0]);
         return this;
     }

--- a/src/main/java/nablarch/core/dataformat/convertor/datatype/Bytes.java
+++ b/src/main/java/nablarch/core/dataformat/convertor/datatype/Bytes.java
@@ -17,6 +17,9 @@ public class Bytes extends ByteStreamDataSupport<byte[]> {
     
     /** {@inheritDoc} */
     public Bytes initialize(Object... args) {
+        if (args == null) {
+            throw new SyntaxErrorException("initialize parameter was null. parameter must be specified. convertor=[Bytes].");
+        }
         if (args.length == 0) {
             throw new SyntaxErrorException("parameter was not specified. parameter must be specified. convertor=[Bytes].");
         }
@@ -55,6 +58,11 @@ public class Bytes extends ByteStreamDataSupport<byte[]> {
         if (!(data instanceof byte[])) {
             throw new InvalidDataFormatException("invalid parameter type was specified. "
                     + "parameter must be a byte array.").setFieldName(getField().getName());
+        }
+        if (((byte[]) data).length != getSize()) {
+            throw new InvalidDataFormatException("invalid parameter was specified."
+                    + " parameter length = [" + ((byte[]) data).length + "], expected = [" + getSize() + "].")
+                    .setFieldName(getField().getName());
         }
         return (byte[]) data;
     }

--- a/src/main/java/nablarch/core/dataformat/convertor/datatype/DecimalHelper.java
+++ b/src/main/java/nablarch/core/dataformat/convertor/datatype/DecimalHelper.java
@@ -68,9 +68,12 @@ public final class DecimalHelper {
      * @return 変換後のデータ
      */
     public static BigDecimal toBigDecimal(Object data, Integer scale) {
-        if (data == null) {
-            throw new InvalidDataFormatException(
-                    "invalid parameter was specified. parameter must not be null.");
+        if (data == null || "".equals(data)) {
+            if (scale != null) {
+                return new BigDecimal(BigInteger.ZERO, scale);
+            } else {
+                return BigDecimal.ZERO;
+            }
         }
         if (data instanceof BigDecimal) {
             return (BigDecimal) data;

--- a/src/main/java/nablarch/core/dataformat/convertor/datatype/NumberStringDecimal.java
+++ b/src/main/java/nablarch/core/dataformat/convertor/datatype/NumberStringDecimal.java
@@ -2,6 +2,7 @@ package nablarch.core.dataformat.convertor.datatype;
 
 import java.io.UnsupportedEncodingException;
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
@@ -315,8 +316,11 @@ public class NumberStringDecimal extends ByteStreamDataSupport<BigDecimal> {
     /** {@inheritDoc} */
     @Override
     public DataType<BigDecimal, byte[]> initialize(Object... args) {
-        
-
+        if (args == null) {
+            throw new SyntaxErrorException(Builder.concat(
+                    "initialize parameter was null. parameter must be specified. convertor=[",
+                    getClass().getSimpleName(), "]."));
+        }
         // 第1引数はバイト長（必須項目）
         if (args.length == 0) {
             throw new SyntaxErrorException(Builder.concat(
@@ -367,8 +371,7 @@ public class NumberStringDecimal extends ByteStreamDataSupport<BigDecimal> {
      */
     public BigDecimal convertOnRead(byte[] data) {
         if (data == null) {
-            throw new InvalidDataFormatException(
-                    "invalid parameter was specified. parameter must not be null.");
+            return new BigDecimal(BigInteger.ZERO, this.scale);
         }
         String strData;
         try {
@@ -402,7 +405,7 @@ public class NumberStringDecimal extends ByteStreamDataSupport<BigDecimal> {
      * @param data 入力データまたは出力データ
      */
     protected void validateReadDataFormat(String data) {
-        if (!dataPattern.matcher(data).matches()) {
+        if (!dataPattern.matcher(data).matches() && !"".equals(data)) {
             throw new InvalidDataFormatException(Builder.concat(
                     "invalid parameter format was specified. parameter format must be [", dataPattern, "]."
                    , " parameter=[", data, "]."));

--- a/src/main/java/nablarch/core/dataformat/convertor/datatype/PackedDecimal.java
+++ b/src/main/java/nablarch/core/dataformat/convertor/datatype/PackedDecimal.java
@@ -87,6 +87,9 @@ public class PackedDecimal extends ByteStreamDataSupport<BigDecimal> {
 
     /** {@inheritDoc} */
     public PackedDecimal initialize(Object... args) {
+        if (args == null) {
+            throw new SyntaxErrorException("initialize parameter was null. parameter must be specified. convertor=[PackedDecimal].");
+        }
         if (args.length == 0) {
             throw new SyntaxErrorException("parameter was not specified. parameter must be specified. convertor=[PackedDecimal].");
         }

--- a/src/main/java/nablarch/core/dataformat/convertor/datatype/SignedNumberStringDecimal.java
+++ b/src/main/java/nablarch/core/dataformat/convertor/datatype/SignedNumberStringDecimal.java
@@ -377,7 +377,7 @@ public class SignedNumberStringDecimal extends NumberStringDecimal {
      * @param pattern パターン
      */
     private void validateFormat(String strData, Pattern pattern) {
-        if (!pattern.matcher(strData).matches()) {
+        if (!pattern.matcher(strData).matches() && !"".equals(strData)) {
             throw new InvalidDataFormatException(Builder.concat(
                     "invalid parameter format was specified. parameter format must be [", pattern, "]."
                   , " parameter=[", strData, "]."));

--- a/src/main/java/nablarch/core/dataformat/convertor/datatype/ZonedDecimal.java
+++ b/src/main/java/nablarch/core/dataformat/convertor/datatype/ZonedDecimal.java
@@ -85,6 +85,9 @@ public class ZonedDecimal extends ByteStreamDataSupport<BigDecimal> {
 
     /** {@inheritDoc} */
     public ZonedDecimal initialize(Object... args) {
+        if (args == null) {
+            throw new SyntaxErrorException("initialize parameter was null. parameter must be specified. convertor=[ZonedDecimal].");
+        }
         if (args.length == 0) {
             throw new SyntaxErrorException("parameter was not specified. parameter must be specified. convertor=[ZonedDecimal].");
         }

--- a/src/test/java/nablarch/core/dataformat/convertor/datatype/ByteStreamDataStringTest.java
+++ b/src/test/java/nablarch/core/dataformat/convertor/datatype/ByteStreamDataStringTest.java
@@ -56,16 +56,16 @@ public class ByteStreamDataStringTest {
 	}
 
     /** 指定ファイルから一行読み込む */
-	private String readLineFrom(File outputFile, String encoding)
-			throws UnsupportedEncodingException, FileNotFoundException {
-		BufferedReader reader = new BufferedReader(
-				new InputStreamReader(new FileInputStream(outputFile), encoding));
-		try {
-			return reader.readLine();
-		} catch (IOException e) {
-			throw new RuntimeException(e);
-		}
-	}
+    private String readLineFrom(File outputFile, String encoding)
+            throws UnsupportedEncodingException, FileNotFoundException {
+        BufferedReader reader = new BufferedReader(
+                new InputStreamReader(new FileInputStream(outputFile), encoding));
+        try {
+            return reader.readLine();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
 	
     /**
      * マルチバイト文字の読み込みができることの確認。
@@ -722,7 +722,17 @@ public class ByteStreamDataStringTest {
         }
         
     }
-    
+
+    /**
+     * 入力時にパラメータが空白の場合のテスト。
+     * 固定長を扱うため、nullがわたされることはないため考慮しない。
+     */
+    @Test
+    public void testReadParameterEmpty() throws Exception {
+        ByteStreamDataString MultiByteCharacter = new ByteStreamDataString();
+        MultiByteCharacter.init(new FieldDefinition().setEncoding(Charset.forName("MS932")), 10);
+        assertThat(MultiByteCharacter.convertOnRead("".getBytes()), is(""));
+    }
     /**
      * 出力時にパラメータがnullまたは空白の場合のテスト。
      */

--- a/src/test/java/nablarch/core/dataformat/convertor/datatype/ByteStreamDataStringTest.java
+++ b/src/test/java/nablarch/core/dataformat/convertor/datatype/ByteStreamDataStringTest.java
@@ -8,7 +8,9 @@ import nablarch.core.dataformat.InvalidDataFormatException;
 import nablarch.core.dataformat.SyntaxErrorException;
 import nablarch.test.support.tool.Hereis;
 import org.hamcrest.CoreMatchers;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -37,6 +39,9 @@ import static org.junit.Assert.fail;
  * @author Masato Inoue
  */
 public class ByteStreamDataStringTest {
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
 
     /** 読み込み用フォーマッタを生成する */
 	private DataRecordFormatter createReadFormatter(String value, String encoding) {
@@ -702,7 +707,20 @@ public class ByteStreamDataStringTest {
 
         assertThat(readRecord.getString("multiByteString"), is("aaaa111"));
     }
-    
+
+    /**
+     * 初期化時にnullをわたすと例外がスローされること。
+     */
+    @Test
+    public void testInitializeNull() {
+        ByteStreamDataString datatype = new ByteStreamDataString();
+
+        exception.expect(SyntaxErrorException.class);
+        exception.expectMessage("initialize parameter was null. parameter must be specified. convertor=[ByteStreamDataString].");
+
+        datatype.initialize(null);
+    }
+
     /**
      * 初期化時のパラメータ不正テスト。
      */

--- a/src/test/java/nablarch/core/dataformat/convertor/datatype/BytesTest.java
+++ b/src/test/java/nablarch/core/dataformat/convertor/datatype/BytesTest.java
@@ -258,6 +258,31 @@ public class BytesTest {
     }
 
     /**
+     * 初期化時の第一引数（バイト長）に0を設定すると例外がスローされること。
+     */
+    @Test
+    public void testInitializeSizeZero() {
+        Bytes datatype = new Bytes();
+
+        exception.expect(SyntaxErrorException.class);
+        exception.expectMessage("invalid parameter was specified. 1st parameter must be positive number, but was [0].");
+
+        datatype.initialize(0, null);
+    }
+    /**
+     * 初期化時の第一引数（バイト長）に負数を設定すると例外がスローされること。
+     */
+    @Test
+    public void testInitializeSizeNegative() {
+        Bytes datatype = new Bytes();
+
+        exception.expect(SyntaxErrorException.class);
+        exception.expectMessage("invalid parameter was specified. 1st parameter must be positive number, but was [-1].");
+
+        datatype.initialize(-1, null);
+    }
+
+    /**
      * 出力時にバイト以外のデータを渡した場合。
      */
     @Test
@@ -302,12 +327,12 @@ public class BytesTest {
     }
 
     /**
-     * 出力時にパラメータがnullまたは空白の場合のテスト。
+     * 出力時にパラメータがnullまたは空文字の場合のテスト。
      */
     @Test
     public void testWriteParameterNullOrEmpty() {
         Bytes bytes = new Bytes();
-        bytes.init(new FieldDefinition(), 0);
+        bytes.init(new FieldDefinition(), 1);
         try {
             bytes.convertOnWrite(null);
             fail();
@@ -315,21 +340,21 @@ public class BytesTest {
             assertThat(e.getMessage(), is("invalid parameter was specified. parameter must be not null."));
         }
         try {
-            bytes.convertOnWrite("");
+            bytes.convertOnWrite("".getBytes());
             fail();
         } catch (InvalidDataFormatException e) {
-            assertTrue(true);
+            assertThat(e.getMessage(), is("invalid parameter was specified. parameter length = [0], expected = [1]."));
         }
     }
 
     /**
-     * 入力時にパラメータが空白の場合のテスト。
+     * 入力時にパラメータが空文字の場合のテスト。
      * 固定長を扱うため、nullがわたされることはないため考慮しない。
      */
     @Test
     public void testReadParameterEmpty() {
         Bytes bytes = new Bytes();
-        bytes.init(new FieldDefinition(), 0);
+        bytes.init(new FieldDefinition(), 2);
 
         assertThat(bytes.convertOnRead("".getBytes()), is("".getBytes()));
     }

--- a/src/test/java/nablarch/core/dataformat/convertor/datatype/BytesTest.java
+++ b/src/test/java/nablarch/core/dataformat/convertor/datatype/BytesTest.java
@@ -243,7 +243,19 @@ public class BytesTest {
             assertEquals("1st parameter was null. parameter=[null, null]. convertor=[Bytes].", e.getMessage());
         }
     }
-    
+
+    /**
+     * 初期化時にnullをわたすと例外がスローされること。
+     */
+    @Test
+    public void testInitializeNull() {
+        Bytes datatype = new Bytes();
+
+        exception.expect(SyntaxErrorException.class);
+        exception.expectMessage("initialize parameter was null. parameter must be specified. convertor=[Bytes].");
+
+        datatype.initialize(null);
+    }
 
     /**
      * 出力時にバイト以外のデータを渡した場合。
@@ -295,12 +307,19 @@ public class BytesTest {
     @Test
     public void testWriteParameterNullOrEmpty() {
         Bytes bytes = new Bytes();
-        bytes.init(new FieldDefinition(), 10);
-        byte[] expected = new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00,
-                                       0x00, 0x00, 0x00, 0x00, 0x00};
-        assertThat(bytes.convertOnWrite(null), is(expected));
-
-        assertThat(bytes.convertOnWrite(""), is(expected));
+        bytes.init(new FieldDefinition(), 0);
+        try {
+            bytes.convertOnWrite(null);
+            fail();
+        } catch (InvalidDataFormatException e){
+            assertThat(e.getMessage(), is("invalid parameter was specified. parameter must be not null."));
+        }
+        try {
+            bytes.convertOnWrite("");
+            fail();
+        } catch (InvalidDataFormatException e) {
+            assertTrue(true);
+        }
     }
 
     /**

--- a/src/test/java/nablarch/core/dataformat/convertor/datatype/CharacterStreamDataStringTest.java
+++ b/src/test/java/nablarch/core/dataformat/convertor/datatype/CharacterStreamDataStringTest.java
@@ -1,7 +1,12 @@
 package nablarch.core.dataformat.convertor.datatype;
 
+import nablarch.core.dataformat.DataRecord;
+import nablarch.core.dataformat.DataRecordFormatter;
+import nablarch.core.dataformat.FormatterFactory;
+import nablarch.test.support.tool.Hereis;
 import org.junit.Test;
 
+import java.io.*;
 import java.math.BigDecimal;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -15,16 +20,41 @@ import static org.junit.Assert.assertThat;
 public class CharacterStreamDataStringTest {
 
     /**
-     * nullが渡された場合に、空文字に変換が行われることのテスト
+     * 初期化時にnullが渡されたときのテスト。
+     * {@link CharacterStreamDataSupport}では初期化時になにもしないため、nullを許容する。
+     */
+    @Test
+    public void testInitializeNull() {
+        CharacterStreamDataString dataType = new CharacterStreamDataString();
+
+        assertThat(dataType.initialize(null), is((DataType<String, String>)dataType));
+    }
+
+    /**
+     * 読込のテスト。
+     * 空文字とそれ以外をテストする。
+     */
+    @Test
+    public void testReadParameterEmpty() {
+        CharacterStreamDataString dataType = new CharacterStreamDataString();
+
+        assertThat(dataType.convertOnRead(""), is(""));
+        assertThat(dataType.convertOnRead("abc"), is("abc"));
+    }
+
+    /**
+     * 出力のテスト。
+     * nullが渡された場合に、空文字に変換が行われること。
      */
     @Test
     public void testWriteObjectNotBigDecimal() {
         CharacterStreamDataString dataType = new CharacterStreamDataString();
 
-        /*
-         * nullの場合
-         */
+        assertThat(dataType.convertOnWrite("abc"), is("abc"));
+        // null の場合
         assertThat(dataType.convertOnWrite(null), is(""));
+        // 空文字の場合
+        assertThat(dataType.convertOnWrite(""), is(""));
     }
 
     @Test
@@ -34,5 +64,54 @@ public class CharacterStreamDataStringTest {
         assertThat(sut.convertOnWrite(BigDecimal.ONE), is("1"));
         assertThat(sut.convertOnWrite(new BigDecimal("0.0000000001")), is("0.0000000001"));
                 
+    }
+
+    /**
+     * 出力時にnullが渡された場合、デフォルト値を出力するテスト。
+     */
+    @Test
+    public void testWriteDefault() throws Exception {
+
+        File formatFile = Hereis.file("./format.fmt");
+        /**********************************************
+         # ファイルタイプ
+         file-type:    "Variable"
+         # 文字列型フィールドの文字エンコーディング
+         text-encoding: "utf8"
+         # 改行コード
+         record-separator: "\r\n"
+         # csv
+         field-separator: ","
+
+         # データレコード定義
+         [Default]
+         1    string     X   "0123"
+         ***************************************************/
+        formatFile.deleteOnExit();
+        File outputFile = new File("record.dat");
+        DataRecordFormatter formatter = createWriteFormatter(formatFile, outputFile);
+        formatter.writeRecord(new DataRecord(){{
+            put("string", null);
+        }});
+        assertThat(readLineFrom(outputFile, "utf8"), is("0123"));
+    }
+
+    /** 書き込み用フォーマッタを生成する */
+    private DataRecordFormatter createWriteFormatter(File formatFile, File outputFile)
+            throws FileNotFoundException {
+        DataRecordFormatter formatter = FormatterFactory.getInstance().setCacheLayoutFileDefinition(false).createFormatter(formatFile);
+        formatter.setOutputStream(new FileOutputStream(outputFile)).initialize();
+        return formatter;
+    }
+    /** 指定ファイルから一行読み込む */
+    private String readLineFrom(File outputFile, String encoding)
+            throws UnsupportedEncodingException, FileNotFoundException {
+        BufferedReader reader = new BufferedReader(
+                new InputStreamReader(new FileInputStream(outputFile), encoding));
+        try {
+            return reader.readLine();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/src/test/java/nablarch/core/dataformat/convertor/datatype/DoubleByteCharacterStringTest.java
+++ b/src/test/java/nablarch/core/dataformat/convertor/datatype/DoubleByteCharacterStringTest.java
@@ -1,19 +1,14 @@
 package nablarch.core.dataformat.convertor.datatype;
 
-import nablarch.core.dataformat.DataRecord;
-import nablarch.core.dataformat.DataRecordFormatter;
-import nablarch.core.dataformat.FieldDefinition;
-import nablarch.core.dataformat.FormatterFactory;
+import nablarch.core.dataformat.*;
 import nablarch.core.util.FilePathSetting;
 import nablarch.test.support.tool.Hereis;
 import org.junit.After;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.InputStream;
+import java.io.*;
 import java.nio.charset.Charset;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -34,7 +29,10 @@ import static org.junit.Assert.assertThat;
 public class DoubleByteCharacterStringTest {
 
     private DataRecordFormatter formatter = null;
-    
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
     @After
     public void tearDown() throws Exception {
         if(formatter != null) {
@@ -188,7 +186,32 @@ public class DoubleByteCharacterStringTest {
         
         assertEquals("あいうえお１１１１１", new String(buffer, "ms932"));
     }
-    
+
+    /**
+     * 初期化時にnullが渡されたときのテスト。
+     */
+    @Test
+    public void testInitializeNull() {
+        DoubleByteCharacterString doubleByteCharacter = new DoubleByteCharacterString();
+
+        exception.expect(SyntaxErrorException.class);
+        exception.expectMessage("1st parameter was null. parameter=[null, hoge]. convertor=[DoubleByteCharacterString].");
+
+        doubleByteCharacter.initialize(null, "hoge");
+    }
+
+    /**
+     * 読込のテスト。
+     * 空文字とそれ以外をテストする。
+     */
+    @Test
+    public void testReadParameterEmpty() {
+        DoubleByteCharacterString dataType = new DoubleByteCharacterString();
+        dataType.init(new FieldDefinition().setEncoding(Charset.forName("utf8")), 10);
+
+        assertThat(dataType.convertOnRead("".getBytes()), is(""));
+        assertThat(dataType.convertOnRead("あいう".getBytes()), is("あいう"));
+    }
 
     /**
      * 出力時にパラメータがnullまたは空白の場合のテスト。
@@ -200,6 +223,54 @@ public class DoubleByteCharacterStringTest {
         assertThat("　　　　　".getBytes("MS932"), is(doubleByteCharacter.convertOnWrite(null)));
         assertThat("　　　　　".getBytes("MS932"), is(doubleByteCharacter.convertOnWrite("")));
     }
-    
-    
+
+    /**
+     * 出力時にパラメータがnullのとき、デフォルト値を書き込めることのテスト。
+     */
+    @Test
+    public void testWriteDefault() throws Exception {
+
+        File formatFile = Hereis.file("./format.fmt");
+        /**********************************************
+         # ファイルタイプ
+         file-type:    "Fixed"
+         # 文字列型フィールドの文字エンコーディング
+         text-encoding: "sjis"
+         # 各レコードの長さ
+         record-length: 20
+
+         # データレコード定義
+         [Default]
+         1    doubleByteString     N(20)    "０１２３４５６７８９"
+         ***************************************************/
+        formatFile.deleteOnExit();
+
+        File outputFile = new File("record.dat");
+
+        DataRecordFormatter formatter = createWriteFormatter(formatFile, outputFile);
+        formatter.writeRecord(new DataRecord(){{
+            put("doubleByteString", null);
+        }});
+        assertThat(readLineFrom(outputFile, "sjis"), is("０１２３４５６７８９"));
+    }
+
+    /** 書き込み用フォーマッタを生成する */
+    private DataRecordFormatter createWriteFormatter(File formatFile, File outputFile)
+            throws FileNotFoundException {
+        DataRecordFormatter formatter = FormatterFactory.getInstance().setCacheLayoutFileDefinition(false).createFormatter(formatFile);
+        formatter.setOutputStream(new FileOutputStream(outputFile)).initialize();
+        return formatter;
+    }
+
+    /** 指定ファイルから一行読み込む */
+    private String readLineFrom(File outputFile, String encoding)
+            throws UnsupportedEncodingException, FileNotFoundException {
+        BufferedReader reader = new BufferedReader(
+                new InputStreamReader(new FileInputStream(outputFile), encoding));
+        try {
+            return reader.readLine();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
 }

--- a/src/test/java/nablarch/core/dataformat/convertor/datatype/DoubleByteCharacterStringTest.java
+++ b/src/test/java/nablarch/core/dataformat/convertor/datatype/DoubleByteCharacterStringTest.java
@@ -188,10 +188,23 @@ public class DoubleByteCharacterStringTest {
     }
 
     /**
-     * 初期化時にnullが渡されたときのテスト。
+     * 初期化時にnullをわたすと例外がスローされること。
      */
     @Test
     public void testInitializeNull() {
+        DoubleByteCharacterString datatype = new DoubleByteCharacterString();
+
+        exception.expect(SyntaxErrorException.class);
+        exception.expectMessage("initialize parameter was null. parameter must be specified. convertor=[DoubleByteCharacterString].");
+
+        datatype.initialize(null);
+    }
+
+    /**
+     * 初期化時の第一引数にnullが渡されたときのテスト。
+     */
+    @Test
+    public void testInitialize1stParameterNull() {
         DoubleByteCharacterString doubleByteCharacter = new DoubleByteCharacterString();
 
         exception.expect(SyntaxErrorException.class);

--- a/src/test/java/nablarch/core/dataformat/convertor/datatype/JsonBooleanTest.java
+++ b/src/test/java/nablarch/core/dataformat/convertor/datatype/JsonBooleanTest.java
@@ -1,7 +1,12 @@
 package nablarch.core.dataformat.convertor.datatype;
 
+import nablarch.core.dataformat.DataRecord;
+import nablarch.core.dataformat.DataRecordFormatter;
+import nablarch.core.dataformat.FormatterFactory;
+import nablarch.test.support.tool.Hereis;
 import org.junit.Test;
 
+import java.io.*;
 import java.math.BigDecimal;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -16,6 +21,17 @@ import static org.junit.Assert.assertThat;
 public class JsonBooleanTest {
 
     /**
+     * 初期化時にnullが渡されたときのテスト。
+     * {@link JsonBoolean}では初期化時になにもしないため、nullを許容する。
+     */
+    @Test
+    public void testInitializeNull() {
+        JsonBoolean dataType = new JsonBoolean();
+
+        assertThat(dataType.initialize(null), is((DataType<String, String>)dataType));
+    }
+
+    /**
      * 読み取り時のテスト
      */
     @Test
@@ -26,6 +42,7 @@ public class JsonBooleanTest {
         assertEquals("data", converter.convertOnRead("data"));
         assertEquals("\"data", converter.convertOnRead("\"data"));
         assertEquals("data\"", converter.convertOnRead("data\""));
+        assertEquals("", converter.convertOnRead(""));
         assertEquals(null, converter.convertOnRead(null));
     }
     
@@ -40,7 +57,7 @@ public class JsonBooleanTest {
         assertEquals("\"data\"", converter.convertOnWrite("\"data\""));
         assertEquals("\"data", converter.convertOnWrite("\"data"));
         assertEquals("data\"", converter.convertOnWrite("data\""));
-        
+        assertEquals("", converter.convertOnWrite(""));
         // nullはnull
         assertEquals(null, converter.convertOnWrite(null));
     }
@@ -54,5 +71,50 @@ public class JsonBooleanTest {
 
         assertThat(sut.convertOnWrite(BigDecimal.ONE), is("1"));
         assertThat(sut.convertOnWrite(new BigDecimal("0.0000000001")), is("0.0000000001"));
+    }
+
+    /**
+     * 出力時にnullが渡された場合、デフォルト値を出力するテスト。
+     */
+    @Test
+    public void testWriteDefault() throws Exception {
+
+        File formatFile = Hereis.file("./format.fmt");
+        /**********************************************
+         # ファイルタイプ
+         file-type:    "JSON"
+         # 文字列型フィールドの文字エンコーディング
+         text-encoding: "UTF-8"
+
+         # データレコード定義
+         [Default]
+         1    bool     BL   "true"
+         ***************************************************/
+        formatFile.deleteOnExit();
+        File outputFile = new File("record.dat");
+        DataRecordFormatter formatter = createWriteFormatter(formatFile, outputFile);
+        formatter.writeRecord(new DataRecord(){{
+            put("bool", null);
+        }});
+        assertThat(readLineFrom(outputFile, "UTF-8"), is("{\"bool\":true}"));
+    }
+
+    /** 書き込み用フォーマッタを生成する */
+    private DataRecordFormatter createWriteFormatter(File formatFile, File outputFile)
+            throws FileNotFoundException {
+        DataRecordFormatter formatter = FormatterFactory.getInstance().setCacheLayoutFileDefinition(false).createFormatter(formatFile);
+        formatter.setOutputStream(new FileOutputStream(outputFile)).initialize();
+        return formatter;
+    }
+    /** 指定ファイルから一行読み込む */
+    private String readLineFrom(File outputFile, String encoding)
+            throws UnsupportedEncodingException, FileNotFoundException {
+        BufferedReader reader = new BufferedReader(
+                new InputStreamReader(new FileInputStream(outputFile), encoding));
+        try {
+            return reader.readLine();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/src/test/java/nablarch/core/dataformat/convertor/datatype/JsonNumberTest.java
+++ b/src/test/java/nablarch/core/dataformat/convertor/datatype/JsonNumberTest.java
@@ -1,12 +1,18 @@
 package nablarch.core.dataformat.convertor.datatype;
 
+import nablarch.core.dataformat.DataRecord;
+import nablarch.core.dataformat.DataRecordFormatter;
+import nablarch.core.dataformat.FormatterFactory;
+import nablarch.test.support.tool.Hereis;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.*;
 import java.math.BigDecimal;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
 /**
  * {@link JsonNumber}のテスト
@@ -14,6 +20,17 @@ import static org.junit.Assert.assertEquals;
  * @author TIS
  */
 public class JsonNumberTest {
+
+    /**
+     * 初期化時にnullが渡されたときのテスト。
+     * {@link JsonNumber}では初期化時になにもしないため、nullを許容する。
+     */
+    @Test
+    public void testInitializeNull() {
+        JsonNumber dataType = new JsonNumber();
+
+        assertThat(dataType.initialize(null), is((DataType<String, String>)dataType));
+    }
 
     /**
      * 読み取り時のテスト
@@ -26,6 +43,7 @@ public class JsonNumberTest {
         assertEquals("data", converter.convertOnRead("data"));
         assertEquals("\"data", converter.convertOnRead("\"data"));
         assertEquals("data\"", converter.convertOnRead("data\""));
+        assertEquals("", converter.convertOnRead(""));
         assertEquals(null, converter.convertOnRead(null));
     }
     
@@ -40,7 +58,7 @@ public class JsonNumberTest {
         assertEquals("\"data\"", converter.convertOnWrite("\"data\""));
         assertEquals("\"data", converter.convertOnWrite("\"data"));
         assertEquals("data\"", converter.convertOnWrite("data\""));
-        
+        assertEquals("", converter.convertOnWrite(""));
         // nullはnull
         assertEquals(null, converter.convertOnWrite(null));
     }
@@ -54,5 +72,50 @@ public class JsonNumberTest {
         final JsonNumber sut = new JsonNumber();
         Assert.assertThat(sut.convertOnWrite(new BigDecimal(("1"))), is("1"));
         Assert.assertThat(sut.convertOnWrite(new BigDecimal("0.0000000001")), is("0.0000000001"));
+    }
+
+    /**
+     * 出力時にnullが渡された場合、デフォルト値を出力するテスト。
+     */
+    @Test
+    public void testWriteDefault() throws Exception {
+
+        File formatFile = Hereis.file("./format.fmt");
+        /**********************************************
+         # ファイルタイプ
+         file-type:    "JSON"
+         # 文字列型フィールドの文字エンコーディング
+         text-encoding: "UTF-8"
+
+         # データレコード定義
+         [Default]
+         1    number     X9   "123"
+         ***************************************************/
+        formatFile.deleteOnExit();
+        File outputFile = new File("record.dat");
+        DataRecordFormatter formatter = createWriteFormatter(formatFile, outputFile);
+        formatter.writeRecord(new DataRecord(){{
+            put("number", null);
+        }});
+        assertThat(readLineFrom(outputFile, "UTF-8"), is("{\"number\":123}"));
+    }
+
+    /** 書き込み用フォーマッタを生成する */
+    private DataRecordFormatter createWriteFormatter(File formatFile, File outputFile)
+            throws FileNotFoundException {
+        DataRecordFormatter formatter = FormatterFactory.getInstance().setCacheLayoutFileDefinition(false).createFormatter(formatFile);
+        formatter.setOutputStream(new FileOutputStream(outputFile)).initialize();
+        return formatter;
+    }
+    /** 指定ファイルから一行読み込む */
+    private String readLineFrom(File outputFile, String encoding)
+            throws UnsupportedEncodingException, FileNotFoundException {
+        BufferedReader reader = new BufferedReader(
+                new InputStreamReader(new FileInputStream(outputFile), encoding));
+        try {
+            return reader.readLine();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/src/test/java/nablarch/core/dataformat/convertor/datatype/JsonObjectTest.java
+++ b/src/test/java/nablarch/core/dataformat/convertor/datatype/JsonObjectTest.java
@@ -16,6 +16,17 @@ import static org.junit.Assert.assertThat;
 public class JsonObjectTest {
 
     /**
+     * 初期化時にnullが渡されたときのテスト。
+     * {@link JsonObject}では初期化時になにもしないため、nullを許容する。
+     */
+    @Test
+    public void testInitializeNull() {
+        JsonObject dataType = new JsonObject();
+
+        assertThat(dataType.initialize(null), is((DataType<String, String>)dataType));
+    }
+
+    /**
      * 読み取り時のテスト
      */
     @Test
@@ -26,6 +37,7 @@ public class JsonObjectTest {
         assertEquals("data", converter.convertOnRead("data"));
         assertEquals("\"data", converter.convertOnRead("\"data"));
         assertEquals("data\"", converter.convertOnRead("data\""));
+        assertEquals("", converter.convertOnRead(""));
         assertEquals(null, converter.convertOnRead(null));
     }
     
@@ -40,7 +52,7 @@ public class JsonObjectTest {
         assertEquals("\"data\"", converter.convertOnWrite("\"data\""));
         assertEquals("\"data", converter.convertOnWrite("\"data"));
         assertEquals("data\"", converter.convertOnWrite("data\""));
-        
+        assertEquals("", converter.convertOnWrite(""));
         // nullはnull
         assertEquals(null, converter.convertOnWrite(null));
     }

--- a/src/test/java/nablarch/core/dataformat/convertor/datatype/JsonStringTest.java
+++ b/src/test/java/nablarch/core/dataformat/convertor/datatype/JsonStringTest.java
@@ -16,6 +16,17 @@ import static org.junit.Assert.assertThat;
 public class JsonStringTest {
 
     /**
+     * 初期化時にnullが渡されたときのテスト。
+     * {@link JsonString}では初期化時になにもしないため、nullを許容する。
+     */
+    @Test
+    public void testInitializeNull() {
+        JsonString dataType = new JsonString();
+
+        assertThat(dataType.initialize(null), is((DataType<String, String>)dataType));
+    }
+
+    /**
      * 読み取り時のテスト
      */
     @Test
@@ -26,6 +37,7 @@ public class JsonStringTest {
         assertEquals("data", converter.convertOnRead("data"));
         assertEquals("\"data", converter.convertOnRead("\"data"));
         assertEquals("data\"", converter.convertOnRead("data\""));
+        assertEquals("", converter.convertOnRead(""));
         assertEquals(null, converter.convertOnRead(null));
     }
     
@@ -40,7 +52,7 @@ public class JsonStringTest {
         assertEquals("\"data\"", converter.convertOnWrite("\"data\""));
         assertEquals("\"data", converter.convertOnWrite("\"data"));
         assertEquals("data\"", converter.convertOnWrite("data\""));
-        
+        assertEquals("", converter.convertOnWrite(""));
         // nullはnull
         assertEquals(null, converter.convertOnWrite(null));
     }

--- a/src/test/java/nablarch/core/dataformat/convertor/datatype/NullableStringTest.java
+++ b/src/test/java/nablarch/core/dataformat/convertor/datatype/NullableStringTest.java
@@ -53,8 +53,10 @@ public class NullableStringTest {
         assertEquals("\"data", converter.convertOnWrite("\"data"));
         assertEquals("data\"", converter.convertOnWrite("data\""));
         assertEquals("", converter.convertOnWrite(""));
-        // nullは空文字に変換する
-        assertEquals("", converter.convertOnWrite(null));
+        // nullは空文字に変換する（別案件となるため、別途対応する）
+        //assertEquals("", converter.convertOnWrite(null));
+        // 現行では null は null
+        assertEquals(null, converter.convertOnWrite(null));
     }
 
     /**

--- a/src/test/java/nablarch/core/dataformat/convertor/datatype/NullableStringTest.java
+++ b/src/test/java/nablarch/core/dataformat/convertor/datatype/NullableStringTest.java
@@ -16,6 +16,17 @@ import static org.junit.Assert.assertThat;
 public class NullableStringTest {
 
     /**
+     * 初期化時にnullが渡されたときのテスト。
+     * {@link NullableString}では初期化時になにもしないため、nullを許容する。
+     */
+    @Test
+    public void testInitializeNull() {
+        NullableString dataType = new NullableString();
+
+        assertThat(dataType.initialize(null), is((DataType<String, String>)dataType));
+    }
+
+    /**
      * 読み取り時のテスト
      */
     @Test
@@ -26,6 +37,7 @@ public class NullableStringTest {
         assertEquals("data", converter.convertOnRead("data"));
         assertEquals("\"data", converter.convertOnRead("\"data"));
         assertEquals("data\"", converter.convertOnRead("data\""));
+        assertEquals("", converter.convertOnRead(""));
         assertEquals(null, converter.convertOnRead(null));
     }
     
@@ -40,9 +52,9 @@ public class NullableStringTest {
         assertEquals("\"data\"", converter.convertOnWrite("\"data\""));
         assertEquals("\"data", converter.convertOnWrite("\"data"));
         assertEquals("data\"", converter.convertOnWrite("data\""));
-        
-        // nullはnull
-        assertEquals(null, converter.convertOnWrite(null));
+        assertEquals("", converter.convertOnWrite(""));
+        // nullは空文字に変換する
+        assertEquals("", converter.convertOnWrite(null));
     }
 
     /**

--- a/src/test/java/nablarch/core/dataformat/convertor/datatype/NumberStringDecimalTest.java
+++ b/src/test/java/nablarch/core/dataformat/convertor/datatype/NumberStringDecimalTest.java
@@ -40,7 +40,34 @@ public class NumberStringDecimalTest {
     public ExpectedException exception = ExpectedException.none();
 
     /**
+     * 初期化時にnullをわたすと例外がスローされること。
+     */
+    @Test
+    public void testInitializeNull() {
+        NumberStringDecimal datatype = new NumberStringDecimal();
+
+        exception.expect(SyntaxErrorException.class);
+        exception.expectMessage("initialize parameter was null. parameter must be specified. convertor=[NumberStringDecimal].");
+
+        datatype.initialize(null);
+    }
+
+    /**
      * 初期化時にnullが渡されたときのテスト。
+     */
+    @Test
+    public void testInitialize1stParameterNull() {
+        NumberStringDecimal datatype = new NumberStringDecimal();
+
+        exception.expect(SyntaxErrorException.class);
+        exception.expectMessage("1st parameter was null. parameter=[null, hoge]. convertor=[NumberStringDecimal].");
+
+        datatype.initialize(null, "hoge");
+    }
+
+    /**
+     * 初期化時にnullが渡されたときのテスト。
+     * initをオーバーライドしたため、init内でinitializeが呼ばれていることを確かめる。
      */
     @Test
     public void testInitNull() {
@@ -50,19 +77,6 @@ public class NumberStringDecimalTest {
         exception.expectMessage("1st parameter was null. parameter=[null, hoge]. convertor=[NumberStringDecimal].");
 
         datatype.init(null, null, "hoge");
-    }
-
-    /**
-     * 初期化時にnullが渡されたときのテスト。
-     */
-    @Test
-    public void testInitializeNull() {
-        NumberStringDecimal datatype = new NumberStringDecimal();
-
-        exception.expect(SyntaxErrorException.class);
-        exception.expectMessage("1st parameter was null. parameter=[null, hoge]. convertor=[NumberStringDecimal].");
-
-        datatype.initialize(null, "hoge");
     }
 
     /**

--- a/src/test/java/nablarch/core/dataformat/convertor/datatype/PackedDecimalTest.java
+++ b/src/test/java/nablarch/core/dataformat/convertor/datatype/PackedDecimalTest.java
@@ -10,7 +10,9 @@ import nablarch.core.dataformat.convertor.FixedLengthConvertorFactory;
 import nablarch.core.util.FilePathSetting;
 import nablarch.test.support.tool.Hereis;
 import org.junit.After;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.io.BufferedInputStream;
 import java.io.File;
@@ -47,7 +49,10 @@ public class PackedDecimalTest {
     private FixedLengthConvertorFactory factory = new FixedLengthConvertorFactory();
     
     private DataRecordFormatter formatter = null;
-    
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
     @After
     public void tearDown() throws Exception {
         if(formatter != null) {
@@ -591,8 +596,19 @@ public class PackedDecimalTest {
             assertEquals("1st parameter was null. parameter=[null, null]. convertor=[PackedDecimal].", e.getMessage());
         }
     }
-    
-    
+
+    /**
+     * 初期化時にnullをわたすと例外がスローされること。
+     */
+    @Test
+    public void testInitializeNull() {
+        PackedDecimal datatype = new PackedDecimal();
+
+        exception.expect(SyntaxErrorException.class);
+        exception.expectMessage("initialize parameter was null. parameter must be specified. convertor=[PackedDecimal].");
+
+        datatype.initialize(null);
+    }
 
     /**
      * 出力するオブジェクトが文字列

--- a/src/test/java/nablarch/core/dataformat/convertor/datatype/SignedNumberStringDecimalTest.java
+++ b/src/test/java/nablarch/core/dataformat/convertor/datatype/SignedNumberStringDecimalTest.java
@@ -8,7 +8,9 @@ import nablarch.core.dataformat.InvalidDataFormatException;
 import nablarch.core.dataformat.SyntaxErrorException;
 import nablarch.core.util.FilePathSetting;
 import nablarch.test.support.tool.Hereis;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.io.BufferedInputStream;
 import java.io.File;
@@ -32,6 +34,9 @@ import static org.junit.Assert.fail;
  * @author Masato Inoue
  */
 public class SignedNumberStringDecimalTest {
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
 
     /**
      * 符号位置固定かつ符号非必須の場合の読み込みテスト。トリムが正常に行われることを確認。
@@ -395,6 +400,23 @@ public class SignedNumberStringDecimalTest {
         convertor.setRequiredPlusSign(true);
         assertThat(new String(convertor.convertOnWrite("+1234"), "ms932"), is("0000■1234"));
         assertThat(new String(convertor.convertOnWrite("-1234"), "ms932"), is("0000▲1234"));
+    }
+
+    /**
+     * 出力時にパラメータがnullの場合のテスト。
+     */
+    @Test
+    public void testWriteNull() throws Exception {
+        FieldDefinition field = new FieldDefinition().setEncoding(Charset.forName("ms932")).setName("test");
+
+        SignedNumberStringDecimal convertor = (SignedNumberStringDecimal)new SignedNumberStringDecimal().init(field, new Object[]{10, ""});
+        convertor.setFixedSignPosition(true);
+        convertor.setRequiredPlusSign(false);
+
+        exception.expect(InvalidDataFormatException.class);
+        exception.expectMessage("invalid parameter was specified. parameter must not be null.");
+
+        convertor.convertOnWrite(null);
     }
 
     /**

--- a/src/test/java/nablarch/core/dataformat/convertor/datatype/SignedNumberStringDecimalTest.java
+++ b/src/test/java/nablarch/core/dataformat/convertor/datatype/SignedNumberStringDecimalTest.java
@@ -39,10 +39,23 @@ public class SignedNumberStringDecimalTest {
     public ExpectedException exception = ExpectedException.none();
 
     /**
-     * 初期化時にnullが渡されたときのテスト。
+     * 初期化時にnullをわたすと例外がスローされること。
      */
     @Test
     public void testInitializeNull() {
+        SignedNumberStringDecimal datatype = new SignedNumberStringDecimal();
+
+        exception.expect(SyntaxErrorException.class);
+        exception.expectMessage("initialize parameter was null. parameter must be specified. convertor=[SignedNumberStringDecimal].");
+
+        datatype.initialize(null);
+    }
+
+    /**
+     * 初期化時にnullが渡されたときのテスト。
+     */
+    @Test
+    public void testInitialize1stParameterNull() {
         SignedNumberStringDecimal datatype = new SignedNumberStringDecimal();
 
         exception.expect(SyntaxErrorException.class);

--- a/src/test/java/nablarch/core/dataformat/convertor/datatype/SingleByteCharacterStringTest.java
+++ b/src/test/java/nablarch/core/dataformat/convertor/datatype/SingleByteCharacterStringTest.java
@@ -7,7 +7,9 @@ import nablarch.core.dataformat.FormatterFactory;
 import nablarch.core.dataformat.InvalidDataFormatException;
 import nablarch.core.dataformat.SyntaxErrorException;
 import nablarch.test.support.tool.Hereis;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.io.*;
 import java.nio.charset.Charset;
@@ -33,6 +35,9 @@ import static org.junit.Assert.fail;
  * @author Masato Inoue
  */
 public class SingleByteCharacterStringTest {
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
 
     /**
      * シングルバイトのパラメータが数値型でない場合に、例外がスローされることの確認。
@@ -194,7 +199,20 @@ public class SingleByteCharacterStringTest {
             assertThat(e.getFilePath(), endsWith("format.fmt"));
         }
     }
-    
+
+    /**
+     * 初期化時にnullをわたすと例外がスローされること。
+     */
+    @Test
+    public void testInitializeNull() {
+        SingleByteCharacterString datatype = new SingleByteCharacterString();
+
+        exception.expect(SyntaxErrorException.class);
+        exception.expectMessage("initialize parameter was null. parameter must be specified. convertor=[SingleByteCharacterString].");
+
+        datatype.initialize(null);
+    }
+
     /**
      * 初期化時のパラメータ不正テスト。
      */

--- a/src/test/java/nablarch/core/dataformat/convertor/datatype/ZonedDecimalTest.java
+++ b/src/test/java/nablarch/core/dataformat/convertor/datatype/ZonedDecimalTest.java
@@ -10,7 +10,9 @@ import nablarch.core.dataformat.convertor.FixedLengthConvertorFactory;
 import nablarch.core.util.FilePathSetting;
 import nablarch.test.support.tool.Hereis;
 import org.junit.After;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
@@ -44,6 +46,9 @@ public class ZonedDecimalTest {
     private FixedLengthConvertorFactory factory = new FixedLengthConvertorFactory();
     private DataRecordFormatter formatter = null;
 
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
     /** フォーマッタ(read)を生成する。 */
     private void createReadFormatter(File filePath, InputStream source) {
         formatter = new FormatterFactory().setCacheLayoutFileDefinition(false).createFormatter(filePath).setInputStream(source).initialize();
@@ -60,6 +65,19 @@ public class ZonedDecimalTest {
         formatter = FormatterFactory.getInstance().setCacheLayoutFileDefinition(false).createFormatter(filePath);
         formatter.setOutputStream(dest).initialize();
         return formatter;
+    }
+
+    /**
+     * 初期化時にnullをわたすと例外がスローされること。
+     */
+    @Test
+    public void testInitializeNull() {
+        ZonedDecimal datatype = new ZonedDecimal();
+
+        exception.expect(SyntaxErrorException.class);
+        exception.expectMessage("initialize parameter was null. parameter must be specified. convertor=[ZonedDecimal].");
+
+        datatype.initialize(null);
     }
 
     /**


### PR DESCRIPTION
#22 

出力時のパラメータがnullのときのテストを追加。
以下の指針で作られている。
固定長
 　　文字列：null -> デフォルトで桁埋め
 　　数値, バイナリ：null -> 例外　（数値, バイナリとして扱うものは必須で入力すること）
可変長
 　　文字列：null -> 空文字　（nullと出力したくないため）
JSON, XML
 　　null -> null

