### PR TITLE
required-decimal-pointディレクティブが符号なし数値でも有効となるように修正

### DIFF
--- a/src/main/java/nablarch/core/dataformat/FixedLengthDataRecordFormatter.java
+++ b/src/main/java/nablarch/core/dataformat/FixedLengthDataRecordFormatter.java
@@ -12,6 +12,7 @@ import nablarch.core.dataformat.convertor.ConvertorSetting;
 import nablarch.core.dataformat.convertor.FixedLengthConvertorSetting;
 import nablarch.core.dataformat.convertor.datatype.ByteStreamDataSupport;
 import nablarch.core.dataformat.convertor.datatype.DataType;
+import nablarch.core.dataformat.convertor.datatype.NumberStringDecimal;
 import nablarch.core.dataformat.convertor.datatype.PackedDecimal;
 import nablarch.core.dataformat.convertor.datatype.SignedNumberStringDecimal;
 import nablarch.core.dataformat.convertor.datatype.ZonedDecimal;
@@ -491,9 +492,14 @@ public class FixedLengthDataRecordFormatter extends DataRecordFormatterSupport {
             packType.setDefaultPackSignNibbleNegative(packSignNibbleNegative);
             packType.setDefaultPackSignNibblePositive(packSignNibblePositive);
         }
+
+        if (dataType instanceof NumberStringDecimal) {
+            final NumberStringDecimal numberStringDecimal = (NumberStringDecimal) dataType;
+            numberStringDecimal.setRequiredDecimalPoint(isRequiredDecimalPoint);
+        }
+        
         if (dataType instanceof SignedNumberStringDecimal) {
             SignedNumberStringDecimal signedNumberType = (SignedNumberStringDecimal) dataType;
-            signedNumberType.setRequiredDecimalPoint(isRequiredDecimalPoint);
             signedNumberType.setFixedSignPosition(isFixedSignPosition);
             signedNumberType.setRequiredPlusSign(isRequiredPlusSign);
          }

--- a/src/test/java/nablarch/core/dataformat/FixedLengthDataRecordFormatterSingleLayoutTest.java
+++ b/src/test/java/nablarch/core/dataformat/FixedLengthDataRecordFormatterSingleLayoutTest.java
@@ -1510,7 +1510,6 @@ public class FixedLengthDataRecordFormatterSingleLayoutTest {
     }
 
     @Test
-    @Ignore("不具合によりテストが失敗する")
     public void decimalPointをoffにした場合X9とSX9に小数点が出力されないこと() throws Exception {
         final File formatFile = temporaryFolder.newFile("format.fmt");
 
@@ -1534,7 +1533,7 @@ public class FixedLengthDataRecordFormatterSingleLayoutTest {
         record.put("SX9", "-12.4");
         formatter.writeRecord(record);
 
-        assertThat("小数点は出力されない", outputStream.toString("sjis"), is("00112-01240"));
+        assertThat("小数点は出力されない", outputStream.toString("sjis"), is("00112-1240"));
     }
     
     @Test


### PR DESCRIPTION
required-decimal-pointディレクティブが符号なし数値でも有効となるように修正

#40