### PR TITLE
レコードの書き込み毎にflushをするか否かを設定で指定できるように変更

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,5 @@ gradle-app.setting
 *.iml
 
 *.log
+
+target/

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,6 @@
       <version>1.4.0</version>
       <scope>test</scope>
     </dependency>
-
     <dependency>
       <groupId>com.nablarch.framework</groupId>
       <artifactId>nablarch-core-repository</artifactId>
@@ -65,6 +64,12 @@
     <dependency>
       <groupId>com.nablarch.dev</groupId>
       <artifactId>nablarch-test-support</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.nablarch.configuration</groupId>
+      <artifactId>nablarch-main-default-configuration</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/nablarch/core/dataformat/DataFormatConfig.java
+++ b/src/main/java/nablarch/core/dataformat/DataFormatConfig.java
@@ -1,0 +1,30 @@
+package nablarch.core.dataformat;
+
+/**
+ * 汎用データフォーマット機能の設定クラス。
+ *
+ * @author Kiyohito Itoh
+ */
+public class DataFormatConfig {
+
+    private boolean flushEachRecordInWriting = true;
+
+    /**
+     * レコードの書き込み毎にflushをするか否かを取得する。
+     *
+     * デフォルトはtrue。
+     *
+     * @return レコードの書き込み毎にflushする場合はtrue、しない場合はfalse
+     */
+    public boolean isFlushEachRecordInWriting() {
+        return flushEachRecordInWriting;
+    }
+
+    /**
+     * レコードの書き込み毎にflushをするか否かを設定する。
+     * @param flushEachRecordInWriting レコードの書き込み毎にflushする場合はtrue、しない場合はfalse
+     */
+    public void setFlushEachRecordInWriting(boolean flushEachRecordInWriting) {
+        this.flushEachRecordInWriting = flushEachRecordInWriting;
+    }
+}

--- a/src/main/java/nablarch/core/dataformat/DataFormatConfigFinder.java
+++ b/src/main/java/nablarch/core/dataformat/DataFormatConfigFinder.java
@@ -1,0 +1,31 @@
+package nablarch.core.dataformat;
+
+import nablarch.core.repository.SystemRepository;
+
+public class DataFormatConfigFinder {
+
+    /** デフォルトの{@link DataFormatConfig} */
+    private static final DataFormatConfig DEFAULT_DATA_FORMAT_CONFIG = new DataFormatConfig();
+
+    /**
+     * インスタンス化しない
+     */
+    private DataFormatConfigFinder() {
+        // nop
+    }
+
+    /** {@link DataFormatConfig}をリポジトリから取得する際に使用する名前 */
+    private static final String WEB_CONFIG_NAME = "dataFormatConfig";
+
+    /**
+     * 汎用データフォーマット機能の設定を取得する。
+     * @return 汎用データフォーマット機能の設定
+     */
+    public static DataFormatConfig getDataFormatConfig() {
+        DataFormatConfig dataFormatConfig = SystemRepository.get(WEB_CONFIG_NAME);
+        if (dataFormatConfig != null) {
+            return dataFormatConfig;
+        }
+        return DEFAULT_DATA_FORMAT_CONFIG;
+    }
+}

--- a/src/main/java/nablarch/core/dataformat/FileRecordReader.java
+++ b/src/main/java/nablarch/core/dataformat/FileRecordReader.java
@@ -126,8 +126,8 @@ public class FileRecordReader implements Closeable {
             );
         }
     }
-    
-    /** 
+
+    /**
      * 指定されたデータファイルから次のレコードを読み込んで返す。
      * @return データレコード
      */

--- a/src/main/java/nablarch/core/dataformat/FixedLengthDataRecordFormatter.java
+++ b/src/main/java/nablarch/core/dataformat/FixedLengthDataRecordFormatter.java
@@ -718,7 +718,9 @@ public class FixedLengthDataRecordFormatter extends DataRecordFormatterSupport {
                     recordDef.getConditionsToApply(), ".");
         }
         writeRecord(record, recordDef);
-        dest.flush();
+        if (DataFormatConfigFinder.getDataFormatConfig().isFlushEachRecordInWriting()) {
+            dest.flush();
+        }
     }
 
     /**

--- a/src/main/java/nablarch/core/dataformat/StructuredDataRecordFormatterSupport.java
+++ b/src/main/java/nablarch/core/dataformat/StructuredDataRecordFormatterSupport.java
@@ -193,8 +193,10 @@ public abstract class StructuredDataRecordFormatterSupport extends DataRecordFor
         incrementRecordNumber(); // レコード番号をインクリメントする
 
         getDataBuilder().buildData(record, getDefinition(), dest);
-        
-        dest.flush();
+
+        if (DataFormatConfigFinder.getDataFormatConfig().isFlushEachRecordInWriting()) {
+            dest.flush();
+        }
     }
 
     /**

--- a/src/main/java/nablarch/core/dataformat/VariableLengthDataRecordFormatter.java
+++ b/src/main/java/nablarch/core/dataformat/VariableLengthDataRecordFormatter.java
@@ -734,7 +734,9 @@ public class VariableLengthDataRecordFormatter extends DataRecordFormatterSuppor
             writeField(record, recordType.getFields().get(i));
         }
         writer.write(getRecordSeparator());
-        writer.flush();
+        if (DataFormatConfigFinder.getDataFormatConfig().isFlushEachRecordInWriting()) {
+            writer.flush();
+        }
     }
 
     /**

--- a/src/test/java/nablarch/common/io/FileRecordWriterHolderBufferTest.java
+++ b/src/test/java/nablarch/common/io/FileRecordWriterHolderBufferTest.java
@@ -1,0 +1,361 @@
+package nablarch.common.io;
+
+import nablarch.core.dataformat.DataFormatConfigFinder;
+import nablarch.core.dataformat.FormatterFactory;
+import nablarch.core.repository.SystemRepository;
+import nablarch.core.util.FilePathSetting;
+import nablarch.test.support.tool.Hereis;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * {@link FileRecordWriterHolder}のバッファリングのテスト。
+ *
+ * @link Kiyohito Itoh
+ */
+public class FileRecordWriterHolderBufferTest {
+
+    @Before
+    public void setUp() {
+
+        DataFormatConfigFinder.getDataFormatConfig().setFlushEachRecordInWriting(true);
+        FormatterFactory.getInstance().setCacheLayoutFileDefinition(false);
+        FileRecordWriterHolder.closeAll();
+
+        SystemRepository.clear();
+
+        FilePathSetting.getInstance().setBasePathSettings(
+                new HashMap<String, String>() {{
+                    put("input",  "file:./");
+                    put("format", "file:./");
+                    put("output", "file:./");
+                }}
+        ).addFileExtensions("format", "fmt");
+
+        new File("./test.fmt").delete();
+        new File("./test.out").delete();
+    }
+
+    @After
+    public void tearDown() {
+        DataFormatConfigFinder.getDataFormatConfig().setFlushEachRecordInWriting(true);
+        FormatterFactory.getInstance().setCacheLayoutFileDefinition(true);
+        FileRecordWriterHolder.closeAll();
+        SystemRepository.clear();
+    }
+
+    @Test
+    public void testFixedLengthDataFormatWithoutBuffer() {
+
+        File formatFile = Hereis.file("./test.fmt");
+        /**********************************************
+         file-type: "Fixed"
+         text-encoding: "UTF-8"
+         record-separator: "\n"
+         record-length: 10
+         [data]
+         1 test X(5)
+         6 test1 X(5)
+         ***************************************************/
+
+        Map<String, String> data = new HashMap<String, String>() {{
+            put("test", str('k', 5));
+            put("test1", str('s', 5));
+        }};
+
+        testWriteWithoutBuffer(formatFile, data, 10 + 1); // +1: line feed
+    }
+
+    @Test
+    public void testFixedLengthDataFormatWithBuffer() {
+
+        File formatFile = Hereis.file("./test.fmt");
+        /**********************************************
+         file-type: "Fixed"
+         text-encoding: "UTF-8"
+         record-separator: "\n"
+         record-length: 10
+         [data]
+         1 test X(5)
+         6 test1 X(5)
+         ***************************************************/
+
+        Map<String, String> data = new HashMap<String, String>() {{
+            put("test", str('k', 5));
+            put("test1", str('s', 5));
+        }};
+
+        /*
+        20>220
+        40>440
+        60>660
+        80>880
+         */
+        testWriteWithBuffer(formatFile, data, 10 + 1, 396);
+    }
+
+    @Test
+    public void testVariableLengthDataFormatWithoutBuffer() {
+
+        File formatFile = Hereis.file("./test.fmt");
+        /**********************************************
+         file-type: "Variable"
+         text-encoding: "UTF-8"
+         record-separator: "\n"
+         field-separator: ","
+         [data]
+         1 test X
+         2 test1 X
+         ***************************************************/
+
+        Map<String, String> data = new HashMap<String, String>() {{
+            put("test", str('k', 5));
+            put("test1", str('s', 5));
+        }};
+
+        testWriteWithoutBuffer(formatFile, data, 10 + 2); // +2: separator + line feed
+    }
+
+    @Test
+    public void testVariableLengthDataFormatWithBuffer() {
+
+        File formatFile = Hereis.file("./test.fmt");
+        /**********************************************
+         file-type: "Variable"
+         text-encoding: "UTF-8"
+         record-separator: "\n"
+         field-separator: ","
+         [data]
+         1 test X
+         2 test1 X
+         ***************************************************/
+
+        Map<String, String> data = new HashMap<String, String>() {{
+            put("test", str('k', 500));
+            put("test1", str('s', 500));
+        }};
+
+        /*
+        n:回数
+        w  :アプリから書き込むサイズ
+        BW :BufferedWriter(default buffer size:8,192)が書き込むサイズ
+        OSW:OutputStreamWriter(default buffer size:8,192)が書き込むサイズ
+        BOS:BufferedOutputStream(specified buffer size: 24576)
+         n      w       BW        OSW     BOS
+        ---------------------------------------
+        20 >  20,040   16,384   16,384        0
+        40 >  40,080   32,768   32,768        0
+        60 >  60,120   49,152   32,768   24,576
+        80 >  80,160   65,536‬   65,536   49,152
+        end> 100,200  100,200  100,200  100,200
+        ---------------------------------------
+        wに対してBW+OSWのバッファ16,384を差し引いたサイズがBOSに渡され、
+        BOSのバッファを超えるとファイルに書き込まれる。
+         */
+        testWriteWithBuffer(
+                formatFile, data, 500 + 500 + 2, 24576,
+                new int[] { 0, 0, 24576, 49152, 100200 });
+    }
+
+    @Test
+    public void testStructuredDataFormatWithoutBuffer() {
+
+        File formatFile = Hereis.file("./test.fmt");
+        /**********************************************
+         file-type: "JSON"
+         text-encoding: "UTF-8"
+         [data]
+         1 test X(5)
+         2 test1 X(5)
+         ***************************************************/
+
+        Map<String, String> data = new HashMap<String, String>() {{
+            put("test", str('k', 5));
+            put("test1", str('s', 5));
+        }};
+
+        testWriteWithoutBuffer(formatFile, data, 32); // 32: {"test":"kkkkk","test1":"kkkkk"}
+    }
+
+    @Test
+    public void testStructuredDataFormatWithBuffer() {
+
+        File formatFile = Hereis.file("./test.fmt");
+        /**********************************************
+         file-type: "JSON"
+         text-encoding: "UTF-8"
+         [data]
+         1 test X(5)
+         2 test1 X(5)
+         ***************************************************/
+
+        Map<String, String> data = new HashMap<String, String>() {{
+            put("test", str('k', 5));
+            put("test1", str('s', 5));
+        }};
+
+        /*
+        20>640
+        40>1280
+        60>1920
+        80>2560
+         */
+        testWriteWithBuffer(formatFile, data, 32, 1184);
+    }
+
+    /**
+     * 100回レコードを書き込み、1レコード毎にflushする場合はデータ件数に応じたサイズで書き込まれることを確認。
+     *
+     * @param formatFile フォーマットファイル
+     * @param data フォーマットに応じた1レコードのデータ
+     * @param outRecordLength 1レコードのデータ長
+     */
+    private void testWriteWithoutBuffer(File formatFile, Map<String, String> data, int outRecordLength) {
+
+        int numberOfRecord = 100;
+        int fileSize = numberOfRecord * outRecordLength;
+
+        // The file size before testing is 0
+        assertThat(new File("./test.out").length(), is(0L));
+
+        // Write the data
+        FileRecordWriterHolder.open("test.out", "test");
+        for (int i = 0; i < numberOfRecord; i++) {
+            if (i == 20) {
+                int size = 20 * outRecordLength;
+                assertThat(new File("./test.out").length(), is(Long.valueOf(size)));
+                System.out.println("20>" + new File("./test.out").length());
+            }
+            if (i == 40) {
+                int size = 40 * outRecordLength;
+                assertThat(new File("./test.out").length(), is(Long.valueOf(size)));
+                System.out.println("40>" + new File("./test.out").length());
+            }
+            if (i == 60) {
+                int size = 60 * outRecordLength;
+                assertThat(new File("./test.out").length(), is(Long.valueOf(size)));
+                System.out.println("60>" + new File("./test.out").length());
+            }
+            if (i == 80) {
+                int size = 80 * outRecordLength;
+                assertThat(new File("./test.out").length(), is(Long.valueOf(size)));
+                System.out.println("80>" + new File("./test.out").length());
+            }
+            FileRecordWriterHolder.write(data, "test.out");
+        }
+        FileRecordWriterHolder.closeAll();
+
+        // Checking the file size after writing
+        assertThat(new File("./test.out").length(), is(Long.valueOf(fileSize)));
+        System.out.println("end>" + new File("./test.out").length());
+    }
+
+    /**
+     * 100回レコードを書き込み、1レコード毎にflushしない場合はバッファサイズに応じたサイズで書き込まれることを確認。
+     *
+     * @param formatFile フォーマットファイル
+     * @param data フォーマットに応じた1レコードのデータ
+     * @param outRecordLength 1レコードのデータ長
+     */
+    private void testWriteWithBuffer(File formatFile, Map<String, String> data, int outRecordLength, int bufferSize) {
+
+        DataFormatConfigFinder.getDataFormatConfig().setFlushEachRecordInWriting(false);
+
+        int numberOfRecord = 100;
+
+        // The file size before testing is 0
+        assertThat(new File("./test.out").length(), is(0L));
+
+        // Write the data
+        FileRecordWriterHolder.open("test.out", "test", bufferSize);
+        for (int i = 0; i < numberOfRecord; i++) {
+            if (i == 20) {
+                int size = ((20 * outRecordLength) / bufferSize) * bufferSize;
+                assertThat(new File("./test.out").length(), is(Long.valueOf(size)));
+                System.out.println("20>" + new File("./test.out").length());
+            }
+            if (i == 40) {
+                int size = ((40 * outRecordLength) / bufferSize) * bufferSize;
+                assertThat(new File("./test.out").length(), is(Long.valueOf(size)));
+                System.out.println("40>" + new File("./test.out").length());
+            }
+            if (i == 60) {
+                int size = ((60 * outRecordLength) / bufferSize) * bufferSize;
+                assertThat(new File("./test.out").length(), is(Long.valueOf(size)));
+                System.out.println("60>" + new File("./test.out").length());
+            }
+            if (i == 80) {
+                int size = ((80 * outRecordLength) / bufferSize) * bufferSize;
+                assertThat(new File("./test.out").length(), is(Long.valueOf(size)));
+                System.out.println("80>" + new File("./test.out").length());
+            }
+            FileRecordWriterHolder.write(data, "test.out");
+        }
+        FileRecordWriterHolder.closeAll();
+
+        // Checking the file size after writing
+        assertThat(new File("./test.out").length(), is(Long.valueOf(numberOfRecord * outRecordLength)));
+        System.out.println("end>" + new File("./test.out").length());
+    }
+
+    /**
+     * 100回レコードを書き込み、1レコード毎にflushしない場合はバッファサイズに応じたサイズで書き込まれることを確認。
+     *
+     * @param formatFile フォーマットファイル
+     * @param data フォーマットに応じた1レコードのデータ
+     * @param outRecordLength 1レコードのデータ長
+     */
+    private void testWriteWithBuffer(
+            File formatFile, Map<String, String> data, int outRecordLength, int bufferSize, int[] expectedBufferSizes) {
+
+        DataFormatConfigFinder.getDataFormatConfig().setFlushEachRecordInWriting(false);
+
+        int numberOfRecord = 100;
+
+        // The file size before testing is 0
+        assertThat(new File("./test.out").length(), is(0L));
+
+        // Write the data
+        FileRecordWriterHolder.open("test.out", "test", bufferSize);
+        for (int i = 0; i < numberOfRecord; i++) {
+            if (i == 20) {
+                assertThat(new File("./test.out").length(), is(Long.valueOf(expectedBufferSizes[0])));
+                System.out.println("20>" + new File("./test.out").length());
+            }
+            if (i == 40) {
+                assertThat(new File("./test.out").length(), is(Long.valueOf(expectedBufferSizes[1])));
+                System.out.println("40>" + new File("./test.out").length());
+            }
+            if (i == 60) {
+                assertThat(new File("./test.out").length(), is(Long.valueOf(expectedBufferSizes[2])));
+                System.out.println("60>" + new File("./test.out").length());
+            }
+            if (i == 80) {
+                assertThat(new File("./test.out").length(), is(Long.valueOf(expectedBufferSizes[3])));
+                System.out.println("80>" + new File("./test.out").length());
+            }
+            FileRecordWriterHolder.write(data, "test.out");
+        }
+        FileRecordWriterHolder.closeAll();
+
+        // Checking the file size after writing
+        assertThat(new File("./test.out").length(), is(Long.valueOf(numberOfRecord * outRecordLength)));
+        System.out.println("end>" + new File("./test.out").length());
+    }
+
+    private String str(char c, int length) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < length; i++) {
+            sb.append(c);
+        }
+        return sb.toString();
+    }
+}

--- a/src/test/java/nablarch/common/io/FileRecordWriterHolderPerformanceTest.java
+++ b/src/test/java/nablarch/common/io/FileRecordWriterHolderPerformanceTest.java
@@ -1,0 +1,165 @@
+package nablarch.common.io;
+
+import nablarch.core.dataformat.DataFormatConfigFinder;
+import nablarch.core.dataformat.FormatterFactory;
+import nablarch.core.repository.SystemRepository;
+import nablarch.core.util.FilePathSetting;
+import nablarch.test.support.tool.Hereis;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.assertThat;
+
+/**
+ * 汎用データフォーマットの出力処理の性能テスト。
+ *
+ * 汎用データフォーマットの出力処理は1レコード毎にflushしているため、複数レコードをまとめてバッファリングできない。
+ * 1レコード毎のflushにより、レコード単位で書き込まれる。
+ * ただし、書き込み件数が多い場合は1レコード毎にflushすると書き込み頻度が多くなるため処理時間が長くなる。
+ * このクラスはこれらの問題を再現するためのテストである。
+ *
+ * @author Kiyohito Itoh
+ */
+@Ignore("汎用データフォーマットの出力処理の性能テスト用のクラスなのでCIでは無効とする")
+public class FileRecordWriterHolderPerformanceTest {
+
+    @Before
+    public void setUp() {
+
+        //コメントを外すと1レコード毎のflushをしない。
+        //DataFormatConfigFinder.getDataFormatConfig().setFlushEachRecordInWriting(false);
+
+        FormatterFactory.getInstance().setCacheLayoutFileDefinition(false);
+        FileRecordWriterHolder.closeAll();
+
+        SystemRepository.clear();
+
+        FilePathSetting.getInstance().setBasePathSettings(
+                new HashMap<String, String>() {{
+                    put("input",  "file:./");
+                    put("format", "file:./");
+                    put("output", "file:./");
+                }}
+        ).addFileExtensions("format", "fmt");
+
+        new File("./test.fmt").delete();
+        new File("./test.out").delete();
+    }
+
+    @After
+    public void tearDown() {
+        DataFormatConfigFinder.getDataFormatConfig().setFlushEachRecordInWriting(true);
+    }
+
+    @Test
+    public void testFixedLengthDataFormat() {
+
+        File formatFile = Hereis.file("./test.fmt");
+        /**********************************************
+         file-type: "Fixed"
+         text-encoding: "UTF-8"
+         record-separator: "\n"
+         record-length: 10
+         [data]
+         1 test X(5)
+         6 test1 X(5)
+         ***************************************************/
+
+        Map<String, String> data = new HashMap<String, String>() {{
+            put("test", str('k', 5));
+            put("test1", str('s', 5));
+        }};
+
+        testDataFormat(formatFile, data, 10 + 1); // +1: line feed
+    }
+
+    @Test
+    public void testVariableLengthDataFormat() {
+
+        File formatFile = Hereis.file("./test.fmt");
+        /**********************************************
+         file-type: "Variable"
+         text-encoding: "UTF-8"
+         record-separator: "\n"
+         field-separator: ","
+         [data]
+         1 test X(5)
+         2 test1 X(5)
+         ***************************************************/
+
+        Map<String, String> data = new HashMap<String, String>() {{
+            put("test", str('k', 5));
+            put("test1", str('s', 5));
+        }};
+
+        testDataFormat(formatFile, data, 10 + 2); // +2: separator + line feed
+    }
+
+    @Test
+    public void testStructuredDataFormat() {
+
+        File formatFile = Hereis.file("./test.fmt");
+        /**********************************************
+         file-type: "JSON"
+         text-encoding: "UTF-8"
+         [data]
+         1 test X(5)
+         2 test1 X(5)
+         ***************************************************/
+
+        Map<String, String> data = new HashMap<String, String>() {{
+            put("test", str('k', 5));
+            put("test1", str('s', 5));
+        }};
+
+        testDataFormat(formatFile, data, 32); // 32: {"test":"kkkkk","test1":"kkkkk"}
+    }
+
+    /**
+     * バッファサイス1MBで大量のレコードを書き込む。
+     *
+     * 出力ファイルのテスト前後のサイズをアサートし、処理されていることを確認。
+     * その上で、書き込み時間を標準出力に出力する。
+     *
+     * @param formatFile フォーマットファイル
+     * @param data フォーマットに応じた1レコードのデータ
+     * @param outRecordLength 1レコードのデータ長
+     */
+    private void testDataFormat(File formatFile, Map<String, String> data, int outRecordLength) {
+
+        int numberOfRecord = 3000000;
+
+        // The file size before testing is 0
+        assertThat(new File("./test.out").length(), is(0L));
+
+        // Write the data
+        FileRecordWriterHolder.open("test.out", "test", 1048576);
+        long start = System.currentTimeMillis();
+        for (int i = 0; i < numberOfRecord; i++) {
+            FileRecordWriterHolder.write(data, "test.out");
+        }
+        long stop = System.currentTimeMillis();
+        FileRecordWriterHolder.closeAll();
+
+        // Checking the file size after writing
+        assertThat(new File("./test.out").length(), is(Long.valueOf(numberOfRecord * outRecordLength)));
+
+        // Output the write time
+        System.out.println("[" + ((stop - start) / 1000) + "] seconds");
+    }
+
+    private String str(char c, int length) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < length; i++) {
+            sb.append(c);
+        }
+        return sb.toString();
+    }
+}

--- a/src/test/java/nablarch/core/dataformat/DataFormatConfigFinderTest.java
+++ b/src/test/java/nablarch/core/dataformat/DataFormatConfigFinderTest.java
@@ -1,0 +1,35 @@
+package nablarch.core.dataformat;
+
+import nablarch.core.repository.SystemRepository;
+import nablarch.core.repository.di.ComponentDefinitionLoader;
+import nablarch.core.repository.di.DiContainer;
+import nablarch.core.repository.di.config.xml.XmlComponentDefinitionLoader;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class DataFormatConfigFinderTest {
+
+    @Before
+    public void setUp() {
+        SystemRepository.clear();
+    }
+
+    @After
+    public void tearDown() {
+        SystemRepository.clear();
+    }
+
+    @Test
+    public void testConfiguration() {
+        String configPath = "nablarch/core/dataformat/data-format-config-finder-test.xml";
+        DiContainer container = new DiContainer(new XmlComponentDefinitionLoader(configPath));
+        SystemRepository.load(container);
+        assertThat(
+                DataFormatConfigFinder.getDataFormatConfig().isFlushEachRecordInWriting(),
+                is(Boolean.FALSE));
+    }
+}

--- a/src/test/java/nablarch/core/dataformat/DataFormatConfigFinderTest.java
+++ b/src/test/java/nablarch/core/dataformat/DataFormatConfigFinderTest.java
@@ -15,14 +15,19 @@ public class DataFormatConfigFinderTest {
 
     @Before
     public void setUp() {
+        System.setProperty("nablarch.dataformat.flushEachRecordInWriting", Boolean.TRUE.toString());
         SystemRepository.clear();
     }
 
     @After
     public void tearDown() {
+        System.getProperties().remove("nablarch.dataformat.flushEachRecordInWriting");
         SystemRepository.clear();
     }
 
+    /**
+     * 設定変更のテスト。
+     */
     @Test
     public void testConfiguration() {
         String configPath = "nablarch/core/dataformat/data-format-config-finder-test.xml";
@@ -31,5 +36,18 @@ public class DataFormatConfigFinderTest {
         assertThat(
                 DataFormatConfigFinder.getDataFormatConfig().isFlushEachRecordInWriting(),
                 is(Boolean.FALSE));
+    }
+
+    /**
+     * デフォルトコンフィグレーションのテスト。
+     */
+    @Test
+    public void testDefaultConfiguration() {
+        String configPath = "nablarch/core/dataformat.xml";
+        DiContainer container = new DiContainer(new XmlComponentDefinitionLoader(configPath));
+        SystemRepository.load(container);
+        assertThat(
+                DataFormatConfigFinder.getDataFormatConfig().isFlushEachRecordInWriting(),
+                is(Boolean.TRUE));
     }
 }

--- a/src/test/resources/nablarch/core/dataformat/data-format-config-finder-test.xml
+++ b/src/test/resources/nablarch/core/dataformat/data-format-config-finder-test.xml
@@ -1,0 +1,7 @@
+<component-configuration xmlns="http://tis.co.jp/nablarch/component-configuration"
+                         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                         xsi:schemaLocation="http://tis.co.jp/nablarch/component-configuration /component-configuration.xsd">
+    <component name="dataFormatConfig" class="nablarch.core.dataformat.DataFormatConfig">
+        <property name="flushEachRecordInWriting" value="false" />
+    </component>
+</component-configuration>


### PR DESCRIPTION
ドキュメントへの反映は下記で実施しました。
https://github.com/nablarch/nablarch-document/pull/302

デフォルトコンフィグレーションへの反映は下記で実施しました。
https://github.com/nablarch/nablarch-default-configuration/pull/22

性能テスト用のクラスを作成し、1レコード毎の書き込みをやめ、
バッファ指定で書き込むことで性能改善することを確認済みです。
固定長と可変長は10倍以上
構造(JSON、XML)は2倍