### PR TITLE
JSONで配列の入れ子をパース出来ない問題に対応。

### DIFF
--- a/src/main/java/nablarch/core/util/JsonParser.java
+++ b/src/main/java/nablarch/core/util/JsonParser.java
@@ -359,21 +359,19 @@ public final class JsonParser {
      * 項目セパレータ検出時の処理です。
      */
     private void onItemSeparator() {
-        if ("}".equals(lastToken)) {
-            currentKey = null;
-        } else if ("]".equals(lastToken)) {
-            // NOP
-        } else if (lastTokenType == TokenType.SEPARATOR) {
+        if (lastToken != null && "]}".contains((String) lastToken)) {
+            // オブジェクト、配列の終了処理内で必要な処理は完了しているので何もしない。
+            return;
+        }
+        if (lastToken != null && "[{,:".contains((String) lastToken)) {
             throw new IllegalArgumentException("value is requires");
-
+        }
+        if (currentList != null && currentKey == null) {
+            // 配列の要素
+            currentList.add(lastToken);
         } else {
-            if (currentList != null && currentKey == null) {
-                currentList.add(lastToken);
-
-            } else {
-                currentMap.put(currentKey, lastToken);
-            }
-
+            // オブジェクトのプロパティ
+            currentMap.put(currentKey, lastToken);
             currentKey = null;
         }
     }

--- a/src/main/java/nablarch/core/util/JsonParser.java
+++ b/src/main/java/nablarch/core/util/JsonParser.java
@@ -359,11 +359,14 @@ public final class JsonParser {
      * 項目セパレータ検出時の処理です。
      */
     private void onItemSeparator() {
-        if (lastToken != null && "]}".contains(lastToken)) {
+        if (lastToken != null
+                && ("]".equals(lastToken) || "}".equals(lastToken))) {
             // オブジェクト、配列の終了処理内で必要な処理は完了しているので何もしない。
             return;
         }
-        if (lastToken != null && "[{,:".contains(lastToken)) {
+        if (lastToken != null
+                && ("[".equals(lastToken) || "{".equals(lastToken)
+                    || ",".equals(lastToken) || ":".equals(lastToken))) {
             throw new IllegalArgumentException("value is requires");
         }
         if (currentList != null && currentKey == null) {

--- a/src/main/java/nablarch/core/util/JsonParser.java
+++ b/src/main/java/nablarch/core/util/JsonParser.java
@@ -36,7 +36,7 @@ public final class JsonParser {
     private String currentKey = null;
 
     /** 前回のトークン */
-    private Object lastToken = null;
+    private String lastToken = null;
     /** 前回のトークン種別 */
     private TokenType lastTokenType = null;
 
@@ -352,18 +352,18 @@ public final class JsonParser {
         if (lastTokenType != TokenType.STRING) {
             throw new IllegalArgumentException("key is not string");
         }
-        currentKey = lastToken.toString();
+        currentKey = lastToken;
     }
 
     /**
      * 項目セパレータ検出時の処理です。
      */
     private void onItemSeparator() {
-        if (lastToken != null && "]}".contains((String) lastToken)) {
+        if (lastToken != null && "]}".contains(lastToken)) {
             // オブジェクト、配列の終了処理内で必要な処理は完了しているので何もしない。
             return;
         }
-        if (lastToken != null && "[{,:".contains((String) lastToken)) {
+        if (lastToken != null && "[{,:".contains(lastToken)) {
             throw new IllegalArgumentException("value is requires");
         }
         if (currentList != null && currentKey == null) {

--- a/src/main/java/nablarch/core/util/JsonParser.java
+++ b/src/main/java/nablarch/core/util/JsonParser.java
@@ -361,10 +361,8 @@ public final class JsonParser {
     private void onItemSeparator() {
         if ("}".equals(lastToken)) {
             currentKey = null;
-
         } else if ("]".equals(lastToken)) {
-            currentList = pop(listStack);
-
+            // NOP
         } else if (lastTokenType == TokenType.SEPARATOR) {
             throw new IllegalArgumentException("value is requires");
 

--- a/src/test/java/nablarch/core/util/JsonParserTest.java
+++ b/src/test/java/nablarch/core/util/JsonParserTest.java
@@ -495,4 +495,14 @@ public class JsonParserTest {
             reader.close();
         }
     }
+
+    /**
+     * 入れ子の配列のテスト
+     */
+    @Test
+    public void testNestedArrayParse() throws Exception {
+        final InputStream resource = FileUtil.getResource(
+                "classpath:nablarch/core/util/JsonParserTest/testNestedArrayParse.json");
+        Map<String, Object> result = (Map<String, Object>) new JsonParser().parse(readAll(resource));
+    }
 }

--- a/src/test/java/nablarch/core/util/JsonParserTest.java
+++ b/src/test/java/nablarch/core/util/JsonParserTest.java
@@ -1,10 +1,6 @@
 package nablarch.core.util;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import org.junit.Test;
 
 import java.io.BufferedReader;
 import java.io.InputStream;
@@ -13,7 +9,12 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 @SuppressWarnings("serial")
 public class JsonParserTest {
@@ -255,6 +256,12 @@ public class JsonParserTest {
 
     /**
      * 配列の開始位置が不正
+     * JSONの仕様では二重配列にした場合など、配列の前に":"がないパターンも許容されるが
+     * フォーマット定義ファイルの仕様上、項目には名前をつけるため、配列の前には必ず":"がくる必要がある。
+     * 以下のような構造はJSON上はOKだが、汎用データフォーマット機能上はNG
+     * {"object":[[1,2],[3,4]]}
+     * 以下のようにする必要がある。
+     * {"object":[{"array1":[1,2]},{"array2":[3,4]}]}
      */
     @Test
     public void testInvalidArrayStart() throws Exception {
@@ -479,6 +486,48 @@ public class JsonParserTest {
         assertEquals(expectedMap, result);
     }
 
+    /**
+     * 入れ子の配列のテスト
+     * 配列の中にオブジェクトの配列を持ち、その後ろに項目を持つパターンと
+     * 配列の中に配列が連続で並ぶパターン、3重配列のパターンをテスト。
+     */
+    @Test
+    public void testNestedArrayParse() throws Exception {
+
+        //期待結果Map
+        Map<String, Object> expectedMap =
+                new HashMap<String, Object>() {{
+                    put("NestedArray", new ArrayList<Object>() {{
+                        add(new HashMap<String, Object>() {{
+                            put("key1", "value1");
+                            put("NestedArray1", new ArrayList<Object>() {{
+                                add(new HashMap<String, Object>() {{
+                                    put("NAKey11", "NAValue11");
+                                }});
+                                add(new HashMap<String, Object>() {{
+                                    put("NAKey12", "NAValue12");
+                                }});
+                            }});
+                            put("key2", "value2");
+                            put("NestedArray2", new ArrayList<String>() {{
+                                add("NAValue2");
+                            }});
+                            put("NestedArray3", new ArrayList<Object>() {{
+                                add(new HashMap<String, Object>() {{
+                                    put("NestedArray4", new ArrayList<String>() {{
+                                        add("NAValue4");
+                                    }});
+                                }});
+                            }});
+                        }});
+                    }});
+                }};
+        final InputStream resource = FileUtil.getResource(
+                "classpath:nablarch/core/util/JsonParserTest/testNestedArrayParse.json");
+        Map<String, ?> result = new JsonParser().parse(readAll(resource));
+        assertEquals(expectedMap, result);
+    }
+
     private String readAll(InputStream stream) throws Exception {
         final BufferedReader reader = new BufferedReader(new InputStreamReader(stream, "utf-8"));
         try {
@@ -494,15 +543,5 @@ public class JsonParserTest {
         } finally {
             reader.close();
         }
-    }
-
-    /**
-     * 入れ子の配列のテスト
-     */
-    @Test
-    public void testNestedArrayParse() throws Exception {
-        final InputStream resource = FileUtil.getResource(
-                "classpath:nablarch/core/util/JsonParserTest/testNestedArrayParse.json");
-        Map<String, Object> result = (Map<String, Object>) new JsonParser().parse(readAll(resource));
     }
 }

--- a/src/test/resources/nablarch/core/util/JsonParserTest/testNestedArrayParse.json
+++ b/src/test/resources/nablarch/core/util/JsonParserTest/testNestedArrayParse.json
@@ -1,22 +1,26 @@
 {
-  "hairetu1": [
+  "NestedArray": [
     {
-      "value1": "aaa",
-      "hairetu2": [
+      "key1": "value1",
+      "NestedArray1": [
         {
-          "value2": "bbb"
+          "NAKey11": "NAValue11"
+        },
+        {
+          "NAKey12": "NAValue12"
         }
       ],
-      "value3": "aaa"
-    },
-    {
-      "value1": "aaa",
-      "hairetu2": [
-        {
-          "value2": "bbb"
-        }
+      "key2": "value2",
+      "NestedArray2": [
+        "NAValue2"
       ],
-      "value3": "aaa"
+      "NestedArray3": [
+        {
+          "NestedArray4": [
+            "NAValue4"
+          ]
+        }
+      ]
     }
   ]
 }

--- a/src/test/resources/nablarch/core/util/JsonParserTest/testNestedArrayParse.json
+++ b/src/test/resources/nablarch/core/util/JsonParserTest/testNestedArrayParse.json
@@ -1,0 +1,22 @@
+{
+  "hairetu1": [
+    {
+      "value1": "aaa",
+      "hairetu2": [
+        {
+          "value2": "bbb"
+        }
+      ],
+      "value3": "aaa"
+    },
+    {
+      "value1": "aaa",
+      "hairetu2": [
+        {
+          "value2": "bbb"
+        }
+      ],
+      "value3": "aaa"
+    }
+  ]
+}


### PR DESCRIPTION
配列の終了処理と項目セパレータ(",")の処理内で二重にlistStackからlistを取り出していたため、子配列の後ろに項目セパレータがあるとlistが取得できずNPEが発生していた。
https://github.com/nablarch/nablarch-core-dataformat/blob/c13a374b95194519f4b2b6748ff6ac89ae7adaff/src/main/java/nablarch/core/util/JsonParser.java#L333-L346
https://github.com/nablarch/nablarch-core-dataformat/blob/c13a374b95194519f4b2b6748ff6ac89ae7adaff/src/main/java/nablarch/core/util/JsonParser.java#L358-L368

```
{
    "Array1": [
        {
            "Array2": [
                {
                    "key1": "value1" 
                }
            ],　 　　←★ここのカンマでリストがnullになって、その後NullPointerException
            "key2": "value2"
        }
    ]
}
```

二重になっている処理を削除したことで二重配列、三重配列も問題なく処理できるようにしている。
また、動作には影響しないが、オブジェクトの終了処理と項目セパレータの処理でcurrentKeyに2回nullを代入していた箇所も同時に修正。

調査の過程で、汎用データフォーマット独自のJSON読み取り仕様として、名前のない配列を定義できないことがわかったので、あわせてテストメソッドに説明を追加している。