### PR TITLE
セパレータだけを値に持つJSONが読み取れない事象への対応

### DIFF
--- a/src/main/java/nablarch/core/util/JsonParser.java
+++ b/src/main/java/nablarch/core/util/JsonParser.java
@@ -302,12 +302,14 @@ public final class JsonParser {
         if (currentMap == null) {
             throw new IllegalArgumentException("object ending but current object is null");
 
-        } else if (":".equals(lastToken)) {
+        } else if (lastTokenType == TokenType.SEPARATOR
+                && ":".equals(lastToken)) {
             throw new IllegalArgumentException("incorrect object ending position");
 
-        } else if (!("]".equals(lastToken))
-         && !("}".equals(lastToken))
-         && !"{".equals(lastToken)) {
+        } else if (lastTokenType != TokenType.SEPARATOR
+                || (!("]".equals(lastToken))
+                && !("}".equals(lastToken))
+                && !"{".equals(lastToken))) {
             currentMap.put(currentKey, lastToken);
         }
 
@@ -334,8 +336,9 @@ public final class JsonParser {
      * 配列終了時の処理です。
      */
     private void onEndArray() {
-        if (!"}".equals(lastToken)
-         && !"[".equals(lastToken)) {
+        if (lastTokenType != TokenType.SEPARATOR
+                || (!"}".equals(lastToken) && !"[".equals(lastToken))
+        ) {
             if (currentList == null) {
                 throw new IllegalArgumentException("array end detected, but not started");
             } else {

--- a/src/main/java/nablarch/core/util/JsonParser.java
+++ b/src/main/java/nablarch/core/util/JsonParser.java
@@ -362,14 +362,12 @@ public final class JsonParser {
      * 項目セパレータ検出時の処理です。
      */
     private void onItemSeparator() {
-        if (lastToken != null
-                && ("]".equals(lastToken) || "}".equals(lastToken))) {
+        if (("]".equals(lastToken) || "}".equals(lastToken))) {
             // オブジェクト、配列の終了処理内で必要な処理は完了しているので何もしない。
             return;
         }
-        if (lastToken != null
-                && ("[".equals(lastToken) || "{".equals(lastToken)
-                    || ",".equals(lastToken) || ":".equals(lastToken))) {
+        if (("[".equals(lastToken) || "{".equals(lastToken)
+                || ",".equals(lastToken) || ":".equals(lastToken))) {
             throw new IllegalArgumentException("value is requires");
         }
         if (currentList != null && currentKey == null) {

--- a/src/main/java/nablarch/core/util/JsonParser.java
+++ b/src/main/java/nablarch/core/util/JsonParser.java
@@ -307,8 +307,8 @@ public final class JsonParser {
             throw new IllegalArgumentException("incorrect object ending position");
 
         } else if (lastTokenType != TokenType.SEPARATOR
-                || (!("]".equals(lastToken))
-                && !("}".equals(lastToken))
+                || (!"]".equals(lastToken)
+                && !"}".equals(lastToken)
                 && !"{".equals(lastToken))) {
             currentMap.put(currentKey, lastToken);
         }
@@ -362,12 +362,12 @@ public final class JsonParser {
      * 項目セパレータ検出時の処理です。
      */
     private void onItemSeparator() {
-        if (("]".equals(lastToken) || "}".equals(lastToken))) {
+        if ("]".equals(lastToken) || "}".equals(lastToken)) {
             // オブジェクト、配列の終了処理内で必要な処理は完了しているので何もしない。
             return;
         }
-        if (("[".equals(lastToken) || "{".equals(lastToken)
-                || ",".equals(lastToken) || ":".equals(lastToken))) {
+        if ("[".equals(lastToken) || "{".equals(lastToken)
+                || ",".equals(lastToken) || ":".equals(lastToken)) {
             throw new IllegalArgumentException("value is requires");
         }
         if (currentList != null && currentKey == null) {

--- a/src/test/java/nablarch/core/util/JsonParserTest.java
+++ b/src/test/java/nablarch/core/util/JsonParserTest.java
@@ -528,6 +528,71 @@ public class JsonParserTest {
         assertEquals(expectedMap, result);
     }
 
+    /**
+     * 項目セパレータだけを値にもつ場合のテスト
+     * {"key":"{"}
+     */
+    @Test
+    public void testOnlyObjectStartValue() throws Exception {
+        HashMap<String, Object> expectedMap1 = new HashMap<String, Object>() {{
+            put("key", "{");
+        }};
+        Map<String, ?> result1 = new JsonParser().parse("{\"key\":\"{\"}");
+        assertEquals(expectedMap1, result1);
+    }
+
+    /**
+     * 項目セパレータだけを値にもつ場合のテスト
+     */
+    @Test
+    public void testOnlyObjectEndValue() throws Exception {
+        // {"key":"}"}
+        HashMap<String, Object> expectedMap2 = new HashMap<String, Object>() {{
+            put("key", "}");
+        }};
+        Map<String, ?> result2 = new JsonParser().parse("{\"key\":\"}\"}");
+        assertEquals(expectedMap2, result2);
+    }
+
+    /**
+     * 項目セパレータだけを値にもつ場合のテスト
+     */
+    @Test
+    public void testOnlyArrayStartValue() throws Exception {
+        // {"key":"["}
+        HashMap<String, Object> expectedMap3 = new HashMap<String, Object>() {{
+            put("key", "[");
+        }};
+        Map<String, ?> result3 = new JsonParser().parse("{\"key\":\"[\"}");
+        assertEquals(expectedMap3, result3);
+    }
+
+    /**
+     * 項目セパレータだけを値にもつ場合のテスト
+     */
+    @Test
+    public void testOnlyArrayEndValue() throws Exception {
+        // {"key":"]"}
+        HashMap<String, Object> expectedMap4 = new HashMap<String, Object>() {{
+            put("key", "]");
+        }};
+        Map<String, ?> result4 = new JsonParser().parse("{\"key\":\"]\"}");
+        assertEquals(expectedMap4, result4);
+    }
+
+    /**
+     * 項目セパレータだけを値にもつ場合のテスト
+     */
+    @Test
+    public void testOnlyColonValue() throws Exception {
+        // {"key":":"}
+        HashMap<String, Object> expectedMap5 = new HashMap<String, Object>() {{
+            put("key", ":");
+        }};
+        Map<String, ?> result5 = new JsonParser().parse("{\"key\":\":\"}");
+        assertEquals(expectedMap5, result5);
+    }
+
     private String readAll(InputStream stream) throws Exception {
         final BufferedReader reader = new BufferedReader(new InputStreamReader(stream, "utf-8"));
         try {

--- a/src/test/java/nablarch/core/util/JsonParserTest.java
+++ b/src/test/java/nablarch/core/util/JsonParserTest.java
@@ -529,68 +529,143 @@ public class JsonParserTest {
     }
 
     /**
-     * 項目セパレータだけを値にもつ場合のテスト
+     * セパレータだけを値にもつ場合のテスト
      * {"key":"{"}
      */
     @Test
-    public void testOnlyObjectStartValue() throws Exception {
-        HashMap<String, Object> expectedMap1 = new HashMap<String, Object>() {{
+    public void testOnlyObjectStartValue() {
+        HashMap<String, Object> expectedMap = new HashMap<String, Object>() {{
             put("key", "{");
         }};
-        Map<String, ?> result1 = new JsonParser().parse("{\"key\":\"{\"}");
-        assertEquals(expectedMap1, result1);
+        Map<String, ?> result = new JsonParser().parse("{\"key\":\"{\"}");
+        assertEquals(expectedMap, result);
     }
 
     /**
-     * 項目セパレータだけを値にもつ場合のテスト
+     * セパレータだけを値にもつ場合のテスト
+     * {"key":"}"}
      */
     @Test
-    public void testOnlyObjectEndValue() throws Exception {
-        // {"key":"}"}
-        HashMap<String, Object> expectedMap2 = new HashMap<String, Object>() {{
+    public void testOnlyObjectEndValue() {
+        HashMap<String, Object> expectedMap = new HashMap<String, Object>() {{
             put("key", "}");
         }};
-        Map<String, ?> result2 = new JsonParser().parse("{\"key\":\"}\"}");
-        assertEquals(expectedMap2, result2);
+        Map<String, ?> result = new JsonParser().parse("{\"key\":\"}\"}");
+        assertEquals(expectedMap, result);
     }
 
     /**
-     * 項目セパレータだけを値にもつ場合のテスト
+     * セパレータだけを値にもつ場合のテスト
+     * {"key":"["}
      */
     @Test
-    public void testOnlyArrayStartValue() throws Exception {
-        // {"key":"["}
-        HashMap<String, Object> expectedMap3 = new HashMap<String, Object>() {{
+    public void testOnlyArrayStartValue() {
+        HashMap<String, Object> expectedMap = new HashMap<String, Object>() {{
             put("key", "[");
         }};
-        Map<String, ?> result3 = new JsonParser().parse("{\"key\":\"[\"}");
-        assertEquals(expectedMap3, result3);
+        Map<String, ?> result = new JsonParser().parse("{\"key\":\"[\"}");
+        assertEquals(expectedMap, result);
     }
 
     /**
-     * 項目セパレータだけを値にもつ場合のテスト
+     * セパレータだけを値にもつ場合のテスト
+     * {"key":"]"}
      */
     @Test
-    public void testOnlyArrayEndValue() throws Exception {
-        // {"key":"]"}
-        HashMap<String, Object> expectedMap4 = new HashMap<String, Object>() {{
+    public void testOnlyArrayEndValue() {
+        HashMap<String, Object> expectedMap = new HashMap<String, Object>() {{
             put("key", "]");
         }};
-        Map<String, ?> result4 = new JsonParser().parse("{\"key\":\"]\"}");
-        assertEquals(expectedMap4, result4);
+        Map<String, ?> result = new JsonParser().parse("{\"key\":\"]\"}");
+        assertEquals(expectedMap, result);
     }
 
     /**
-     * 項目セパレータだけを値にもつ場合のテスト
+     * セパレータだけを値にもつ場合のテスト
+     * {"key":":"}
      */
     @Test
-    public void testOnlyColonValue() throws Exception {
-        // {"key":":"}
-        HashMap<String, Object> expectedMap5 = new HashMap<String, Object>() {{
+    public void testOnlyColonValue() {
+        HashMap<String, Object> expectedMap = new HashMap<String, Object>() {{
             put("key", ":");
         }};
-        Map<String, ?> result5 = new JsonParser().parse("{\"key\":\":\"}");
-        assertEquals(expectedMap5, result5);
+        Map<String, ?> result = new JsonParser().parse("{\"key\":\":\"}");
+        assertEquals(expectedMap, result);
+    }
+
+    /**
+     * セパレータだけを値にもつ配列のテスト
+     * {"key":["{"]}
+     */
+    @Test
+    public void testOnlyObjectStartValueInArray() {
+        HashMap<String, Object> expectedMap = new HashMap<String, Object>() {{
+            put("key", new ArrayList<String>() {{
+                add("{");
+            }});
+        }};
+        Map<String, ?> result = new JsonParser().parse("{\"key\":[\"{\"]}");
+        assertEquals(expectedMap, result);
+    }
+
+    /**
+     * セパレータだけを値にもつ配列のテスト
+     * {"key":["}"]}
+     */
+    @Test
+    public void testOnlyObjectEndValueInArray() {
+        HashMap<String, Object> expectedMap = new HashMap<String, Object>() {{
+            put("key", new ArrayList<String>() {{
+                add("}");
+            }});
+        }};
+        Map<String, ?> result = new JsonParser().parse("{\"key\":[\"}\"]}");
+        assertEquals(expectedMap, result);
+    }
+
+    /**
+     * セパレータだけを値にもつ配列のテスト
+     * {"key":["["]}
+     */
+    @Test
+    public void testOnlyArrayStartValueInArray() {
+        HashMap<String, Object> expectedMap = new HashMap<String, Object>() {{
+            put("key", new ArrayList<String>() {{
+                add("[");
+            }});
+        }};
+        Map<String, ?> result = new JsonParser().parse("{\"key\":[\"[\"]}");
+        assertEquals(expectedMap, result);
+    }
+
+    /**
+     * セパレータだけを値にもつ配列のテスト
+     * {"key":["]"]}
+     */
+    @Test
+    public void testOnlyArrayEndValueInArray() {
+        HashMap<String, Object> expectedMap = new HashMap<String, Object>() {{
+            put("key", new ArrayList<String>() {{
+                add("]");
+            }});
+        }};
+        Map<String, ?> result = new JsonParser().parse("{\"key\":[\"]\"]}");
+        assertEquals(expectedMap, result);
+    }
+
+    /**
+     * セパレータだけを値にもつ配列のテスト
+     * {"key":[":"]}
+     */
+    @Test
+    public void testOnlyColonValueInArray() {
+        HashMap<String, Object> expectedMap = new HashMap<String, Object>() {{
+            put("key", new ArrayList<String>() {{
+                add(":");
+            }});
+        }};
+        Map<String, ?> result = new JsonParser().parse("{\"key\":[\":\"]}");
+        assertEquals(expectedMap, result);
     }
 
     private String readAll(InputStream stream) throws Exception {

--- a/src/test/java/nablarch/core/util/JsonParserTest.java
+++ b/src/test/java/nablarch/core/util/JsonParserTest.java
@@ -530,141 +530,141 @@ public class JsonParserTest {
 
     /**
      * セパレータだけを値にもつ場合のテスト
-     * {"key":"{"}
+     * {"{":"{"}
      */
     @Test
     public void testOnlyObjectStartValue() {
         HashMap<String, Object> expectedMap = new HashMap<String, Object>() {{
-            put("key", "{");
+            put("{", "{");
         }};
-        Map<String, ?> result = new JsonParser().parse("{\"key\":\"{\"}");
+        Map<String, ?> result = new JsonParser().parse("{\"{\":\"{\"}");
         assertEquals(expectedMap, result);
     }
 
     /**
      * セパレータだけを値にもつ場合のテスト
-     * {"key":"}"}
+     * {"}":"}"}
      */
     @Test
     public void testOnlyObjectEndValue() {
         HashMap<String, Object> expectedMap = new HashMap<String, Object>() {{
-            put("key", "}");
+            put("}", "}");
         }};
-        Map<String, ?> result = new JsonParser().parse("{\"key\":\"}\"}");
+        Map<String, ?> result = new JsonParser().parse("{\"}\":\"}\"}");
         assertEquals(expectedMap, result);
     }
 
     /**
      * セパレータだけを値にもつ場合のテスト
-     * {"key":"["}
+     * {"[":"["}
      */
     @Test
     public void testOnlyArrayStartValue() {
         HashMap<String, Object> expectedMap = new HashMap<String, Object>() {{
-            put("key", "[");
+            put("[", "[");
         }};
-        Map<String, ?> result = new JsonParser().parse("{\"key\":\"[\"}");
+        Map<String, ?> result = new JsonParser().parse("{\"[\":\"[\"}");
         assertEquals(expectedMap, result);
     }
 
     /**
      * セパレータだけを値にもつ場合のテスト
-     * {"key":"]"}
+     * {"]":"]"}
      */
     @Test
     public void testOnlyArrayEndValue() {
         HashMap<String, Object> expectedMap = new HashMap<String, Object>() {{
-            put("key", "]");
+            put("]", "]");
         }};
-        Map<String, ?> result = new JsonParser().parse("{\"key\":\"]\"}");
+        Map<String, ?> result = new JsonParser().parse("{\"]\":\"]\"}");
         assertEquals(expectedMap, result);
     }
 
     /**
      * セパレータだけを値にもつ場合のテスト
-     * {"key":":"}
+     * {":":":"}
      */
     @Test
     public void testOnlyColonValue() {
         HashMap<String, Object> expectedMap = new HashMap<String, Object>() {{
-            put("key", ":");
+            put(":", ":");
         }};
-        Map<String, ?> result = new JsonParser().parse("{\"key\":\":\"}");
+        Map<String, ?> result = new JsonParser().parse("{\":\":\":\"}");
         assertEquals(expectedMap, result);
     }
 
     /**
      * セパレータだけを値にもつ配列のテスト
-     * {"key":["{"]}
+     * {"{":["{"]}
      */
     @Test
     public void testOnlyObjectStartValueInArray() {
         HashMap<String, Object> expectedMap = new HashMap<String, Object>() {{
-            put("key", new ArrayList<String>() {{
+            put("{", new ArrayList<String>() {{
                 add("{");
             }});
         }};
-        Map<String, ?> result = new JsonParser().parse("{\"key\":[\"{\"]}");
+        Map<String, ?> result = new JsonParser().parse("{\"{\":[\"{\"]}");
         assertEquals(expectedMap, result);
     }
 
     /**
      * セパレータだけを値にもつ配列のテスト
-     * {"key":["}"]}
+     * {"}":["}"]}
      */
     @Test
     public void testOnlyObjectEndValueInArray() {
         HashMap<String, Object> expectedMap = new HashMap<String, Object>() {{
-            put("key", new ArrayList<String>() {{
+            put("}", new ArrayList<String>() {{
                 add("}");
             }});
         }};
-        Map<String, ?> result = new JsonParser().parse("{\"key\":[\"}\"]}");
+        Map<String, ?> result = new JsonParser().parse("{\"}\":[\"}\"]}");
         assertEquals(expectedMap, result);
     }
 
     /**
      * セパレータだけを値にもつ配列のテスト
-     * {"key":["["]}
+     * {"[":["["]}
      */
     @Test
     public void testOnlyArrayStartValueInArray() {
         HashMap<String, Object> expectedMap = new HashMap<String, Object>() {{
-            put("key", new ArrayList<String>() {{
+            put("[", new ArrayList<String>() {{
                 add("[");
             }});
         }};
-        Map<String, ?> result = new JsonParser().parse("{\"key\":[\"[\"]}");
+        Map<String, ?> result = new JsonParser().parse("{\"[\":[\"[\"]}");
         assertEquals(expectedMap, result);
     }
 
     /**
      * セパレータだけを値にもつ配列のテスト
-     * {"key":["]"]}
+     * {"]":["]"]}
      */
     @Test
     public void testOnlyArrayEndValueInArray() {
         HashMap<String, Object> expectedMap = new HashMap<String, Object>() {{
-            put("key", new ArrayList<String>() {{
+            put("]", new ArrayList<String>() {{
                 add("]");
             }});
         }};
-        Map<String, ?> result = new JsonParser().parse("{\"key\":[\"]\"]}");
+        Map<String, ?> result = new JsonParser().parse("{\"]\":[\"]\"]}");
         assertEquals(expectedMap, result);
     }
 
     /**
      * セパレータだけを値にもつ配列のテスト
-     * {"key":[":"]}
+     * {":":[":"]}
      */
     @Test
     public void testOnlyColonValueInArray() {
         HashMap<String, Object> expectedMap = new HashMap<String, Object>() {{
-            put("key", new ArrayList<String>() {{
+            put(":", new ArrayList<String>() {{
                 add(":");
             }});
         }};
-        Map<String, ?> result = new JsonParser().parse("{\"key\":[\":\"]}");
+        Map<String, ?> result = new JsonParser().parse("{\":\":[\":\"]}");
         assertEquals(expectedMap, result);
     }
 

--- a/src/test/java/nablarch/core/util/JsonParserTest.java
+++ b/src/test/java/nablarch/core/util/JsonParserTest.java
@@ -668,6 +668,81 @@ public class JsonParserTest {
         assertEquals(expectedMap, result);
     }
 
+    /**
+     * セパレータだけを値にもつ子オブジェクトのテスト
+     * {"{":{"{":"{"}}
+     */
+    @Test
+    public void testOnlyObjectStartValueInNestedObject() {
+        HashMap<String, Object> expectedMap = new HashMap<String, Object>() {{
+            put("{", new HashMap<String, Object>() {{
+                put("{", "{");
+            }});
+        }};
+        Map<String, ?> result = new JsonParser().parse("{\"{\":{\"{\":\"{\"}}");
+        assertEquals(expectedMap, result);
+    }
+
+    /**
+     * セパレータだけを値にもつ子オブジェクトのテスト
+     * {"}":{"}":"}"}}
+     */
+    @Test
+    public void testOnlyObjectEndValueInNestedObject() {
+        HashMap<String, Object> expectedMap = new HashMap<String, Object>() {{
+            put("}", new HashMap<String, Object>() {{
+                put("}", "}");
+            }});
+        }};
+        Map<String, ?> result = new JsonParser().parse("{\"}\":{\"}\":\"}\"}}");
+        assertEquals(expectedMap, result);
+    }
+
+    /**
+     * セパレータだけを値にもつ子オブジェクトのテスト
+     * {"[":{"[":"["}}
+     */
+    @Test
+    public void testOnlyArrayStartValueInNestedObject() {
+        HashMap<String, Object> expectedMap = new HashMap<String, Object>() {{
+            put("[", new HashMap<String, Object>() {{
+                put("[", "[");
+            }});
+        }};
+        Map<String, ?> result = new JsonParser().parse("{\"[\":{\"[\":\"[\"}}");
+        assertEquals(expectedMap, result);
+    }
+
+    /**
+     * セパレータだけを値にもつ子オブジェクトのテスト
+     * {"]":{"]":"]"}}
+     */
+    @Test
+    public void testOnlyArrayEndValueInNestedObject() {
+        HashMap<String, Object> expectedMap = new HashMap<String, Object>() {{
+            put("]", new HashMap<String, Object>() {{
+                put("]", "]");
+            }});
+        }};
+        Map<String, ?> result = new JsonParser().parse("{\"]\":{\"]\":\"]\"}}");
+        assertEquals(expectedMap, result);
+    }
+
+    /**
+     * セパレータだけを値にもつ子オブジェクトのテスト
+     * {":":{":":":"}}
+     */
+    @Test
+    public void testOnlyColonValueInNestedArray() {
+        HashMap<String, Object> expectedMap = new HashMap<String, Object>() {{
+            put(":", new HashMap<String, Object>() {{
+                put(":", ":");
+            }});
+        }};
+        Map<String, ?> result = new JsonParser().parse("{\":\":{\":\":\":\"}}");
+        assertEquals(expectedMap, result);
+    }
+
     private String readAll(InputStream stream) throws Exception {
         final BufferedReader reader = new BufferedReader(new InputStreamReader(stream, "utf-8"));
         try {


### PR DESCRIPTION
"{"、"}"、"["、"]"を値として1文字だけ持つ場合に空のMapとして読み取られてしまう。

":"を値として持つものは以下のExceptionが送出される。
`java.lang.IllegalArgumentException: incorrect object ending position`

配列に1文字だけ値を持つ場合、"}"、"["が読み取れない。
以下のようなJSONを読み込むと空の配列となってしまう。
`{"key":["}"]}`

上記のようになる理由は以下の通り。
　オブジェクトの終了処理と配列の終了処理内で、直前のトークンによって処理を分岐させている。
　直前のトークンが文字列としての"{"なのかセパレータとしての"{"なのかを判定していなかったため、
　文字列として"{"や"}"を読み取った際にMapにputせずに読み取った値を捨ててしまっていた。
これを修正し、セパレータを文字列としてパースできるようにした。

あわせて#66の対応内で追加した条件のうち、結果に影響を与えない`lastToken != null`の条件を削除した。
https://github.com/nablarch/nablarch-core-dataformat/pull/66/commits/0a9a34ca56cafae693c7c2c8daf9d6b0fb2fc9ef
もともとcontainsメソッドを使用するために入れた条件だが、equalsメソッドに変更したため不要となった。
lastTokenは基本的には何かしらの値が入るためこの条件を削除してもパフォーマンスが大きく劣化することはない。