### PR TITLE
LoggerManager.getの引数を宣言しているクラスに変更

### DIFF
--- a/src/main/java/nablarch/core/dataformat/FixedLengthDataRecordFormatter.java
+++ b/src/main/java/nablarch/core/dataformat/FixedLengthDataRecordFormatter.java
@@ -68,7 +68,7 @@ import nablarch.core.util.annotation.Published;
 public class FixedLengthDataRecordFormatter extends DataRecordFormatterSupport {
 
     /** ロガー * */
-    private static final Logger LOGGER = LoggerManager.get(FileRecordWriter.class);
+    private static final Logger LOGGER = LoggerManager.get(FixedLengthDataRecordFormatter.class);
 
     /** 符号ビットのパターン */
     private static final Pattern SIGN_BIT_FORMAT = Pattern.compile("[a-fA-F0-9]");

--- a/src/main/java/nablarch/core/dataformat/VariableLengthDataRecordFormatter.java
+++ b/src/main/java/nablarch/core/dataformat/VariableLengthDataRecordFormatter.java
@@ -105,7 +105,7 @@ import nablarch.core.util.annotation.Published;
 public class VariableLengthDataRecordFormatter extends DataRecordFormatterSupport {
 
     /** ロガー **/
-    private static final Logger LOGGER = LoggerManager.get(FileRecordWriter.class);
+    private static final Logger LOGGER = LoggerManager.get(VariableLengthDataRecordFormatter.class);
     
     /** コンバータの設定情報保持クラス */
     private VariableLengthConvertorSetting convertorSetting;


### PR DESCRIPTION
FixedLengthDataRecordFormatterとVariableLengthDataRecordFormatterのprivate static final Logger LOGGER = LoggerManager.get(〜～);は
FileRecordWriter.classである必要があるのでしょうか。
宣言しているクラスに変更してみました。

よろしければ、マージいただけると幸いです。