### PR TITLE
xmlunitのバージョンを2.10.0に更新

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,13 +29,13 @@
     <dependency>
       <groupId>org.xmlunit</groupId>
       <artifactId>xmlunit-core</artifactId>
-      <version>2.2.1</version>
+      <version>2.10.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.xmlunit</groupId>
       <artifactId>xmlunit-matchers</artifactId>
-      <version>2.2.1</version>
+      <version>2.10.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
xmlunitは2.8.0からJakarta対応（XMLバインディング）が入っている。
元々2.2.1と古いバージョンを使用しており、推移的依存関係にあるxml-coreやxml-apiも古く、一部競合が発生して最終的にJakarta対応バージョンが使用されているように見えた。

解消するため、最新版の2.10.0に更新。
