### PR TITLE
xmlunitのバージョンを2.10.0に更新

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,13 +29,13 @@
     <dependency>
       <groupId>org.xmlunit</groupId>
       <artifactId>xmlunit-core</artifactId>
-      <version>2.2.1</version>
+      <version>2.10.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.xmlunit</groupId>
       <artifactId>xmlunit-matchers</artifactId>
-      <version>2.2.1</version>
+      <version>2.10.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
xmlunitは[2.8.0でJakarta EEに対応](https://github.com/xmlunit/xmlunit/releases/tag/v2.8.0)されており、JAXBに関する依存関係が更新されている。
現状の使用方法では現在依存している古いバージョンで問題が出ているわけではないが、Jakarta EEに対応している依存関係が望ましいため、最新版である2.10.0に更新する。